### PR TITLE
Fix wrong shared library linking

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,8 +20,8 @@ lib:			libdclass.so libdclass.a
 dclass_client:		libdclass.a main.o
 			$(CC) $(LDFLAGS) -o $@ main.o libdclass.a $(LIBFLAGS)
 
-libdclass.so:		libdclass.a
-			$(CC) $(LDFLAGS) -shared -o $@ libdclass.a
+libdclass.so:		$(CLIENT_OBJS)
+			$(CC) $(LDFLAGS) -shared -o $@ $(CLIENT_OBJS)
 
 libdclass.a:		$(CLIENT_OBJS)
 			ar cr $@ $(CLIENT_OBJS)


### PR DESCRIPTION
The current call to gcc in the makefile can't link the shared library properly. When linking against a static library, only unresolved symbols will be pulled in.
