### PR TITLE
Reindent C source for clarity

### DIFF
--- a/src/dclass_client.c
+++ b/src/dclass_client.c
@@ -1,305 +1,277 @@
 /*
- * Copyright 2012 The Weather Channel
- * Copyright 2013 Reza Naghibi
+ * Copyright 2012 The Weather Channel Copyright 2013 Reza Naghibi
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
  */
-
 
 #include "dclass_client.h"
 
+// cnode
+typedef struct {
+  int pos;
 
-//cnode
-typedef struct
-{
-    int                  pos;
+  const dtree_dt_node *cn;
+} dclass_cnode;
 
-    const dtree_dt_node  *cn;
-}
-dclass_cnode;
-
-
-char **dclass_get_value_pos(dclass_keyvalue*,char*);
-static const dclass_keyvalue *dclass_get_kverror(const dclass_index*);
+char **dclass_get_value_pos(dclass_keyvalue *, char *);
+static const dclass_keyvalue *dclass_get_kverror(const dclass_index *);
 
 extern unsigned int dtree_hash_char(char);
-extern char *dtree_node_path(const dtree_dt_index*,const dtree_dt_node*,char*);
+extern char *dtree_node_path(const dtree_dt_index *, const dtree_dt_node *,
+                             char *);
 
+// classifies a string
+const dclass_keyvalue *dclass_classify(const dclass_index *di,
+                                       const char *str) {
+  int on = 0;
+  int valid;
+  int bcvalid;
+  int i;
+  int pos = 0;
+  int rpos = 0;
+  unsigned int hash;
+  char buf[DTREE_DATA_BUFLEN];
+  const char *p;
+  const char *token = "";
+  packed_ptr pp;
+  const dtree_dt_node *cnode = NULL;
+  const dtree_dt_node *wnode = NULL;
+  const dtree_dt_node *nnode = NULL;
+  const dtree_dt_node *fbnode;
+  const dtree_dt_node *fnode;
+  const dtree_dt_index *h = &di->dti;
+  dclass_cnode cnodes[DTREE_S_MAX_CHAIN];
 
-//classifies a string
-const dclass_keyvalue *dclass_classify(const dclass_index *di,const char *str)
-{
-    int on=0;
-    int valid;
-    int bcvalid;
-    int i;
-    int pos=0;
-    int rpos=0;
-    unsigned int hash;
-    char buf[DTREE_DATA_BUFLEN];
-    const char *p;
-    const char *token="";
-    packed_ptr pp;
-    const dtree_dt_node *cnode=NULL;
-    const dtree_dt_node *wnode=NULL;
-    const dtree_dt_node *nnode=NULL;
-    const dtree_dt_node *fbnode;
-    const dtree_dt_node *fnode;
-    const dtree_dt_index *h=&di->dti;
-    dclass_cnode cnodes[DTREE_S_MAX_CHAIN];
-    
-    if(!str || !h->head)
-        return dclass_get_kverror(di);
-    
-    memset(cnodes,0,sizeof(cnodes));
-    
-    dtree_printd(DTREE_PRINT_CLASSIFY,"dclass_classify() UA: '%s'\n",str);
-    
-    for(p=str;*p;p++)
-    {
-        valid=0;
+  if (!str || !h->head)
+    return dclass_get_kverror(di);
 
-        hash=dtree_hash_char(*p);
-        
-        if(hash<DTREE_HASH_SEP && (hash || *p=='0'))
-        {
-            //new token found
-            if(!on)
-            {
-                token=p;
-                on=1;
+  memset(cnodes, 0, sizeof(cnodes));
 
-                rpos++;
+  dtree_printd(DTREE_PRINT_CLASSIFY, "dclass_classify() UA: '%s'\n", str);
 
-                if(pos<DTREE_S_MAX_POS)
-                    pos++;
-            }
-            
-            valid=1;
+  for (p = str; *p; p++) {
+    valid = 0;
+
+    hash = dtree_hash_char(*p);
+
+    if (hash < DTREE_HASH_SEP && (hash || *p == '0')) {
+      // new token found
+      if (!on) {
+        token = p;
+        on = 1;
+
+        rpos++;
+
+        if (pos < DTREE_S_MAX_POS)
+          pos++;
+      }
+      valid = 1;
+    }
+    if ((!valid || (!*(p + 1))) && on) {
+      // EOT found
+      fbnode = dtree_get_node(h, token, 0, 0);
+
+      dtree_printd(DTREE_PRINT_CLASSIFY,
+                   "dtree_classify() token %d(%d): '%s' = '%s':%d\n", pos, rpos,
+                   token, fbnode ? dtree_node_path(h, fbnode, buf) : "",
+                   fbnode ? (int)fbnode->flags : 0);
+
+      if (fbnode && dtree_get_flag(h, fbnode, DTREE_DT_FLAG_TOKEN, pos)) {
+        if ((fnode = dtree_get_flag(h, fbnode, DTREE_DT_FLAG_STRONG, pos)))
+          return fnode->payload;
+        else if ((fnode = dtree_get_flag(h, fbnode, DTREE_DT_FLAG_WEAK, pos))) {
+          i = DTREE_DC_DISTANCE(h, (char *)fnode->payload);
+          if (!wnode || fnode->rank > wnode->rank ||
+              (fnode->rank == wnode->rank && i >= 0 &&
+               i < DTREE_DC_DISTANCE(h, (char *)wnode->payload)))
+            wnode = fnode;
+        } else if ((fnode =
+                        dtree_get_flag(h, fbnode, DTREE_DT_FLAG_NONE, pos))) {
+          i = DTREE_DC_DISTANCE(h, (char *)fnode->payload);
+          if (!nnode ||
+              (i >= 0 && i < DTREE_DC_DISTANCE(h, (char *)nnode->payload)))
+            nnode = fnode;
         }
-        
-        if((!valid || (!*(p+1))) && on)
-        {
-            //EOT found
-            fbnode=dtree_get_node(h,token,0,0);
-            
-            dtree_printd(DTREE_PRINT_CLASSIFY,"dtree_classify() token %d(%d): '%s' = '%s':%d\n",
-                    pos,rpos,token,fbnode?dtree_node_path(h,fbnode,buf):"",fbnode?(int)fbnode->flags:0);
-            
-            if(fbnode && dtree_get_flag(h,fbnode,DTREE_DT_FLAG_TOKEN,pos))
-            {
-                if((fnode=dtree_get_flag(h,fbnode,DTREE_DT_FLAG_STRONG,pos)))
+        if ((fnode = dtree_get_flag(h, fbnode, DTREE_DT_FLAG_ACHAIN, pos))) {
+          pp = fnode->curr;
+
+          while (pp) {
+            bcvalid = 0;
+
+            if (fnode->flags & DTREE_DT_FLAG_ACHAIN) {
+              if (fnode->cparam)
+                dtree_printd(
+                    DTREE_PRINT_CLASSIFY,
+                    "dtree_classify() looking for pchain %p at dir: %d\n",
+                    fnode->cparam, fnode->dir);
+              else
+                dtree_printd(DTREE_PRINT_CLASSIFY,
+                             "dtree_classify() pchain candidate %p\n",
+                             fnode->payload);
+
+              for (i = 0; i < DTREE_S_MAX_CHAIN && cnodes[i].cn; i++) {
+                // chain hit
+                if (cnodes[i].cn->payload == fnode->cparam && fnode->dir <= 0) {
+                  dtree_printd(
+                      DTREE_PRINT_CLASSIFY,
+                      "dtree_classify() pchain match: %p('%d'):%d %d\n",
+                      cnodes[i].cn->payload, i, cnodes[i].pos, rpos);
+
+                  if (fnode->dir < 0 && cnodes[i].pos - rpos < fnode->dir)
+                    continue;
+                  else if (fnode->flags & DTREE_DT_FLAG_BCHAIN)
+                    bcvalid = 1;
+                  else if (!fnode->rank)
                     return fnode->payload;
-                else if((fnode=dtree_get_flag(h,fbnode,DTREE_DT_FLAG_WEAK,pos)))
-                {
-                    i=DTREE_DC_DISTANCE(h,(char*)fnode->payload);
-                    if(!wnode || fnode->rank>wnode->rank || (fnode->rank==wnode->rank &&
-                            i>=0 && i<DTREE_DC_DISTANCE(h,(char*)wnode->payload)))
-                        wnode=fnode;
+                  else if (!cnode || fnode->rank > cnode->rank)
+                    cnode = fnode;
                 }
-                else if((fnode=dtree_get_flag(h,fbnode,DTREE_DT_FLAG_NONE,pos)))
-                {
-                    i=DTREE_DC_DISTANCE(h,(char*)fnode->payload);
-                    if(!nnode || (i>=0 && i<DTREE_DC_DISTANCE(h,(char*)nnode->payload)))
-                        nnode=fnode;
+                if (cnodes[i].cn->cparam == fnode->payload &&
+                    cnodes[i].cn->dir > 0) {
+                  dtree_printd(
+                      DTREE_PRINT_CLASSIFY,
+                      "dtree_classify() pchain forward match: %p('%d'):%d %d\n",
+                      fnode->payload, i, cnodes[i].pos, rpos);
+
+                  if (rpos - cnodes[i].pos > cnodes[i].cn->dir)
+                    continue;
+                  // forward chain has a dependency, not implemented
+                  else if (fnode->cparam)
+                    ;
+                  else if (!cnodes[i].cn->rank)
+                    return cnodes[i].cn->payload;
+                  else if (!cnode || cnodes[i].cn->rank > cnode->rank)
+                    cnode = cnodes[i].cn;
                 }
-                
-                if((fnode=dtree_get_flag(h,fbnode,DTREE_DT_FLAG_ACHAIN,pos)))
-                {
-                    pp=fnode->curr;
-
-                    while(pp)
-                    {
-                        bcvalid=0;
-                        
-                        if(fnode->flags & DTREE_DT_FLAG_ACHAIN)
-                        {   
-                            if(fnode->cparam)
-                                dtree_printd(DTREE_PRINT_CLASSIFY,"dtree_classify() looking for pchain %p at dir: %d\n",fnode->cparam,fnode->dir);
-                            else
-                                dtree_printd(DTREE_PRINT_CLASSIFY,"dtree_classify() pchain candidate %p\n",fnode->payload);
-
-                            for(i=0;i<DTREE_S_MAX_CHAIN && cnodes[i].cn;i++)
-                            {
-                                //chain hit
-                                if(cnodes[i].cn->payload==fnode->cparam && fnode->dir<=0)
-                                {
-                                    dtree_printd(DTREE_PRINT_CLASSIFY,"dtree_classify() pchain match: %p('%d'):%d %d\n",cnodes[i].cn->payload,i,cnodes[i].pos,rpos);
-
-                                    if(fnode->dir<0 && cnodes[i].pos-rpos<fnode->dir)
-                                        continue;
-                                    else if(fnode->flags & DTREE_DT_FLAG_BCHAIN)
-                                        bcvalid=1;
-                                    else if(!fnode->rank)
-                                        return fnode->payload;
-                                    else if(!cnode || fnode->rank>cnode->rank)
-                                        cnode=fnode;
-                                }
-
-                                if(cnodes[i].cn->cparam==fnode->payload && cnodes[i].cn->dir>0)
-                                {
-                                    dtree_printd(DTREE_PRINT_CLASSIFY,"dtree_classify() pchain forward match: %p('%d'):%d %d\n",fnode->payload,i,cnodes[i].pos,rpos);
-
-                                    if(rpos-cnodes[i].pos>cnodes[i].cn->dir)
-                                        continue;
-                                    //forward chain has a dependency, not implemented
-                                    else if(fnode->cparam);
-                                    else if(!cnodes[i].cn->rank)
-                                        return cnodes[i].cn->payload;
-                                    else if(!cnode || cnodes[i].cn->rank>cnode->rank)
-                                        cnode=cnodes[i].cn;
-                                }
-                            }
-                        }
-                        
-                        if(fnode->flags & DTREE_DT_FLAG_ACHAIN && (bcvalid || !fnode->cparam || fnode->dir>0))
-                        {
-                            for(i=0;i<DTREE_S_MAX_CHAIN;i++)
-                            {
-                                if(!cnodes[i].cn)
-                                {
-                                    cnodes[i].cn=fnode;
-                                    cnodes[i].pos=rpos;
-
-                                    dtree_printd(DTREE_PRINT_CLASSIFY,"dtree_classify() pchain added: %p('%d'):%d\n",fnode->payload,i,rpos);
-
-                                    break;
-                                }
-                            }
-                        }
-                        
-                        pp=fnode->dup;
-                        fnode=DTREE_DT_GETPP(h,pp);
-                    }
-                }
+              }
             }
+            if (fnode->flags & DTREE_DT_FLAG_ACHAIN &&
+                (bcvalid || !fnode->cparam || fnode->dir > 0)) {
+              for (i = 0; i < DTREE_S_MAX_CHAIN; i++) {
+                if (!cnodes[i].cn) {
+                  cnodes[i].cn = fnode;
+                  cnodes[i].pos = rpos;
 
-            if(!*(p+1) && pos<DTREE_S_MAX_POS)
-            {
-                p--;
+                  dtree_printd(DTREE_PRINT_CLASSIFY,
+                               "dtree_classify() pchain added: %p('%d'):%d\n",
+                               fnode->payload, i, rpos);
 
-                if(token==str)
-                    pos=DTREE_S_BE_POS;
-                else
-                    pos=DTREE_S_MAX_POS;
-    
-                continue;
+                  break;
+                }
+              }
             }
-
-            on=0;
+            pp = fnode->dup;
+            fnode = DTREE_DT_GETPP(h, pp);
+          }
         }
-    }
-    
-    if(cnode)
-    {
-        if(wnode && wnode->rank>cnode->rank)
-            return wnode->payload;
+      }
+      if (!*(p + 1) && pos < DTREE_S_MAX_POS) {
+        p--;
 
-        return cnode->payload;
+        if (token == str)
+          pos = DTREE_S_BE_POS;
+        else
+          pos = DTREE_S_MAX_POS;
+
+        continue;
+      }
+      on = 0;
     }
-    else if(wnode)
-        return wnode->payload;
-    else if(nnode)
-        return nnode->payload;
-    
+  }
+
+  if (cnode) {
+    if (wnode && wnode->rank > cnode->rank)
+      return wnode->payload;
+
+    return cnode->payload;
+  } else if (wnode)
+    return wnode->payload;
+  else if (nnode)
+    return nnode->payload;
+
+  return dclass_get_kverror(di);
+}
+
+// gets a string
+const dclass_keyvalue *dclass_get(const dclass_index *di, const char *str) {
+  const dtree_dt_node *node;
+  const dtree_dt_index *h = &di->dti;
+
+  if (!str || !h->head)
     return dclass_get_kverror(di);
+
+  node = dtree_get_node(h, str, DTREE_DT_FLAG_TOKEN, 0);
+
+  if (node && node->payload)
+    return node->payload;
+
+  return dclass_get_kverror(di);
 }
 
+// gets the value for a key
+const char *dclass_get_kvalue(const dclass_keyvalue *kvd, const char *key) {
+  int i;
 
-//gets a string
-const dclass_keyvalue *dclass_get(const dclass_index *di,const char *str)
-{
-    const dtree_dt_node *node;
-    const dtree_dt_index *h=&di->dti;
+  for (i = 0; i < kvd->size; i++) {
+    if (!strcasecmp(kvd->keys[i], key))
+      return kvd->values[i];
+  }
 
-    if(!str || !h->head)
-        return dclass_get_kverror(di);
-
-    node=dtree_get_node(h,str,DTREE_DT_FLAG_TOKEN,0);
-    
-    if(node && node->payload)
-        return node->payload;
-
-    return dclass_get_kverror(di);
+  return NULL;
 }
 
+// gets the value pointer for a key
+char **dclass_get_value_pos(dclass_keyvalue *kvd, char *key) {
+  int i;
 
-//gets the value for a key
-const char *dclass_get_kvalue(const dclass_keyvalue *kvd,const char *key)
-{
-    int i;
-    
-    for(i=0;i<kvd->size;i++)
-    {
-        if(!strcasecmp(kvd->keys[i],key))
-            return kvd->values[i];
-    }
-    
-    return NULL;
+  for (i = 0; i < kvd->size; i++) {
+    if (!strcasecmp(kvd->keys[i], key))
+      return (char **)&kvd->values[i];
+  }
+
+  return NULL;
 }
 
-//gets the value pointer for a key
-char **dclass_get_value_pos(dclass_keyvalue *kvd,char *key)
-{
-    int i;
-    
-    for(i=0;i<kvd->size;i++)
-    {
-        if(!strcasecmp(kvd->keys[i],key))
-            return (char**)&kvd->values[i];
-    }
-    
-    return NULL;
+// returns an error kvdata
+static const dclass_keyvalue *dclass_get_kverror(const dclass_index *di) {
+  return &di->error;
 }
 
-//returns an error kvdata
-static const dclass_keyvalue *dclass_get_kverror(const dclass_index *di)
-{
-    return &di->error;
+// gets the id for a generic payload
+const char *dclass_get_id(void *payload) {
+  dclass_keyvalue *kvd;
+
+  kvd = (dclass_keyvalue *)payload;
+
+  return kvd->id;
 }
 
-//gets the id for a generic payload
-const char *dclass_get_id(void *payload)
-{
-    dclass_keyvalue *kvd;
-    
-    kvd=(dclass_keyvalue*)payload;
-    
-    return kvd->id;
+// version
+const char *dclass_get_version() { return DCLASS_VERSION; }
+
+// init
+void dclass_init_index(dclass_index *di) {
+  memset(&di->error, 0, sizeof(dclass_keyvalue));
+
+  di->error.id = DTREE_M_SERROR;
+
+  dtree_init_index(&di->dti);
 }
 
-//version
-const char *dclass_get_version()
-{
-    return DCLASS_VERSION;
+// free
+void dclass_free(dclass_index *di) {
+  dtree_free(&di->dti);
+
+  dclass_init_index(di);
 }
-
-//init
-void dclass_init_index(dclass_index *di)
-{
-    memset(&di->error,0,sizeof(dclass_keyvalue));
-
-    di->error.id=DTREE_M_SERROR;
-    
-    dtree_init_index(&di->dti);
-}
-
-//free
-void dclass_free(dclass_index *di)
-{
-    dtree_free(&di->dti);
-    
-    dclass_init_index(di);
-}
-

--- a/src/dclass_client.h
+++ b/src/dclass_client.h
@@ -13,60 +13,48 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
-
 
 #ifndef _DCLASS_H_INCLUDED_
 #define _DCLASS_H_INCLUDED_
 
-
 #include "dtree_client.h"
 
+#define DCLASS_VERSION "dClass 2.3.1"
 
-#define DCLASS_VERSION    "dClass 2.3.1"
+// key value struct, dtree payload
+typedef struct {
+  const char *id;
 
+  const char **keys;
+  const char **values;
 
-//key value struct, dtree payload
-typedef struct
-{
-    const char            *id;
-    
-    const char            **keys;
-    const char            **values;
-    
-    unsigned short int    size;
-}
-dclass_keyvalue;
+  unsigned short int size;
+} dclass_keyvalue;
 
+// dclass index
+typedef struct {
+  dtree_dt_index dti;
 
-//dclass index
-typedef struct
-{
-    dtree_dt_index        dti;
-    
-    dclass_keyvalue       error;
-}
-dclass_index;
-
+  dclass_keyvalue error;
+} dclass_index;
 
 #include "devicemap_client.h"
 
+void dclass_init_index(dclass_index *);
 
-void dclass_init_index(dclass_index*);
+int dclass_load_file(dclass_index *, const char *);
+int dclass_write_file(const dclass_index *, const char *);
 
-int dclass_load_file(dclass_index*,const char*);
-int dclass_write_file(const dclass_index*,const char*);
+const dclass_keyvalue *dclass_classify(const dclass_index *, const char *);
+const dclass_keyvalue *dclass_get(const dclass_index *, const char *);
+const char *dclass_get_kvalue(const dclass_keyvalue *, const char *);
 
-const dclass_keyvalue *dclass_classify(const dclass_index*,const char*);
-const dclass_keyvalue *dclass_get(const dclass_index*,const char*);
-const char *dclass_get_kvalue(const dclass_keyvalue*,const char*);
+void dclass_free(dclass_index *);
 
-void dclass_free(dclass_index*);
-
-const char *dclass_get_id(void*);
+const char *dclass_get_id(void *);
 
 const char *dclass_get_version();
 
-
-#endif	/* _DCLASS_H_INCLUDED_ */
+#endif /* _DCLASS_H_INCLUDED_ */

--- a/src/dclass_file.c
+++ b/src/dclass_file.c
@@ -13,797 +13,726 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
-
 
 #include "dclass_client.h"
 
+// structs for parsing dtree file
+typedef struct {
+  char *key;
+  char *value;
 
-//structs for parsing dtree file
-typedef struct
-{
-    char *key;
-    char *value;
-    
-    size_t key_len;
-    size_t val_len;
-}
-dtree_kv_pair;
+  size_t key_len;
+  size_t val_len;
+} dtree_kv_pair;
 
-typedef struct
-{
-    char *pattern;
-    char *id;
-    char *cparam;
-    char *type;
-    
-    size_t pattern_len;
-    size_t id_len;
-    size_t cparam_len;
-    
-    int count;
-    
-    dtree_flag_f flag;
+typedef struct {
+  char *pattern;
+  char *id;
+  char *cparam;
+  char *type;
 
-    unsigned int pos;
-    unsigned int rank;
-    signed int dir;
-    
-    dtree_kv_pair p[DTREE_DATA_MKEYS];
-}
-dtree_file_entry;
+  size_t pattern_len;
+  size_t id_len;
+  size_t cparam_len;
 
+  int count;
 
-static void dclass_parse_fentry(char*,dtree_file_entry*,int);
-static long dclass_write_tree(const dtree_dt_index*,const dtree_dt_node*,char*,int,FILE*);
-static void dclass_write_node(const dtree_dt_node*,char*,FILE*);
+  dtree_flag_f flag;
+
+  unsigned int pos;
+  unsigned int rank;
+  signed int dir;
+
+  dtree_kv_pair p[DTREE_DATA_MKEYS];
+} dtree_file_entry;
+
+static void dclass_parse_fentry(char *, dtree_file_entry *, int);
+static long dclass_write_tree(const dtree_dt_index *, const dtree_dt_node *,
+                              char *, int, FILE *);
+static void dclass_write_node(const dtree_dt_node *, char *, FILE *);
 
 extern unsigned int dtree_hash_char(char);
 
-
 #if DTREE_PERF_WALKING
-extern void dtree_timersubn(struct timespec*,struct timespec*,struct timespec*);
-extern int dtree_gettime(struct timespec*);
+extern void dtree_timersubn(struct timespec *, struct timespec *,
+                            struct timespec *);
+extern int dtree_gettime(struct timespec *);
 #endif
 
+// parses a dtree file
+int dclass_load_file(dclass_index *di, const char *path) {
+  int i, j;
+  int ret;
+  int lines = 0;
+  int keys_size = 0;
+  char *p;
+  char *s;
+  char **keys = NULL;
+  char buf[10 * 1024];
+  FILE *f;
+  dtree_dt_index ids;
+  dtree_dt_index *h = &di->dti;
+  dtree_file_entry fe;
+  dclass_keyvalue *kvd;
+  dclass_keyvalue *cparam;
+  dtree_dt_add_entry entry;
 
-//parses a dtree file
-int dclass_load_file(dclass_index *di,const char *path)
-{
-    int i,j;
-    int ret;
-    int lines=0;
-    int keys_size=0;
-    char *p;
-    char *s;
-    char **keys=NULL;
-    char buf[10*1024];
-    FILE *f;
-    dtree_dt_index ids;
-    dtree_dt_index *h=&di->dti;
-    dtree_file_entry fe;
-    dclass_keyvalue *kvd;
-    dclass_keyvalue *cparam;
-    dtree_dt_add_entry entry;
-    
 #if DTREE_PERF_WALKING
-    struct timespec startn,endn,diffn;
-    long total,high,low,val,lret;
+  struct timespec startn, endn, diffn;
+  long total, high, low, val, lret;
 #endif
-    
-    dclass_init_index(di);
-    dtree_init_index(&ids);
-    
-    dtree_printd(DTREE_PRINT_GENERIC,"DTREE: Loading '%s'\n",path);
-    
-    if(!(f=fopen(path,"r")))
-    {
-        fprintf(stderr,"DTREE: cannot open '%s'\n",path);
-        return -1;
-    }
-    
-    //traverse the loadfile
-    while((buf[sizeof(buf)-2]='\n') && (p=fgets(buf,sizeof(buf),f)))
-    {
-        lines++;
-        
-        //overflow
-        if(buf[sizeof(buf)-2]!='\n' && buf[sizeof(buf)-2])
-        {
-            dtree_printd(DTREE_PRINT_INITDTREE,"LOAD: overflow detected on line %d\n",lines);
-            
-            do
-            {
-                buf[sizeof(buf)-2]='\n';
-                
-                if(!fgets(buf,sizeof(buf),f))
-                    break;
-            }
-            while(buf[sizeof(buf)-2]!='\n' && buf[sizeof(buf)-2]);
-            
-            continue;
-        }
-        
-        if(*buf=='#')
-        {
-            switch(*++p)
-            {
-                //string order is being forced here
-                case '!':
-                    for(++p,s=p;*p;p++)
-                    {
-                        if(*p==',' || !*(p+1))
-                        {
-                            *p='\0';
-                            s=dtree_alloc_string(h,s,p-s);
-                            dtree_printd(DTREE_PRINT_INITDTREE,"INIT FORCE string: '%s'\n",s);
-                            
-                            kvd=(dclass_keyvalue*)dtree_alloc_mem(h,sizeof(dclass_keyvalue));
-            
-                            if(!kvd)
-                                goto lerror;
 
-                            kvd->id=s;
+  dclass_init_index(di);
+  dtree_init_index(&ids);
 
-                            memset(&entry,0,sizeof(dtree_dt_add_entry));
+  dtree_printd(DTREE_PRINT_GENERIC, "DTREE: Loading '%s'\n", path);
 
-                            entry.data=kvd;
-
-                            if(dtree_add_entry(&ids,kvd->id,&entry)<0)
-                                goto lerror;
-
-                            dtree_printd(DTREE_PRINT_INITDTREE,"IDS: Successful add: '%s'\n",kvd->id);
-                            
-                            s=(p+1);
-                        }
-                    }
-                    break;
-                //index params
-                case '$':
-                    p++;
-                    if(!strncasecmp(p,"partial",6))
-                    {
-                        h->sflags |= DTREE_S_FLAG_PARTIAL;
-                        dtree_printd(DTREE_PRINT_INITDTREE,"INIT FORCE: partial\n");
-                    }
-                    else if(!strncasecmp(p,"regex",5))
-                    {
-                        h->sflags |= DTREE_S_FLAG_REGEX;
-                        dtree_printd(DTREE_PRINT_INITDTREE,"INIT FORCE: regex\n");
-                    }
-                    else if(!strncasecmp(p,"dups",4))
-                    {
-                        h->sflags |= DTREE_S_FLAG_DUPS;
-                        dtree_printd(DTREE_PRINT_INITDTREE,"INIT FORCE: dups\n");
-                    }
-                    else if(!strncasecmp(p,"notrim",6))
-                    {
-                        h->sflags |= DTREE_S_FLAG_NOTRIM;
-                        dtree_printd(DTREE_PRINT_INITDTREE,"INIT FORCE: notrim\n");
-                    }
-                    break;
-                //kv error id
-                case '@':
-                    p++;
-                    for(s=p;*p;p++)
-                    {
-                        if(*p=='\n')
-                            break;
-                    }
-                    *p='\0';
-                    di->error.id=dtree_alloc_string(h,s,p-s+1);
-                //comment
-                default:
-                    if(!h->comment)
-                    {
-                        if(*p==' ')
-                            p++;
-                        for(s=p;*p;p++)
-                        {
-                            if(*p=='\n')
-                                break;
-                        }
-                        *p='\0';
-                        h->comment=dtree_alloc_mem(h,(p-s+1)*sizeof(char));
-                        if(h->comment)
-                            strncpy(h->comment,s,p-s);
-                    }
-                    break;
-            }          
-            continue;
-        }
-        
-        memset(&fe,0,sizeof(fe));
-        
-        //parse the line
-        dclass_parse_fentry(buf,&fe,h->sflags & DTREE_S_FLAG_NOTRIM);
-        
-        if(!fe.id)
-        {
-            dtree_printd(DTREE_PRINT_INITDTREE,"LOAD: bad line detected: '%s':%d\n",buf,lines);
-            continue;
-        }
-                
-        if(fe.type)
-        {
-            for(s=fe.type;*s;s++)
-            {
-                if(*s==':')
-                {
-                    s++;
-                    fe.pos=strtol(s,NULL,10);
-                    break;
-                }
-                else if(fe.flag)
-                    continue;
-                else if(*s=='S')
-                    fe.flag=DTREE_DT_FLAG_STRONG;
-                else if(*s=='W')
-                {
-                    fe.flag=DTREE_DT_FLAG_WEAK;
-                    if(*(s+1)>='0' && *(s+1)<='9')
-                        fe.rank=strtol(s+1,NULL,10);
-                }
-                else if(*s=='B')
-                    fe.flag=DTREE_DT_FLAG_BCHAIN;
-                else if(*s=='C')
-                {
-                    fe.flag=DTREE_DT_FLAG_CHAIN;
-                    if(*(s+1)>='0' && *(s+1)<='9')
-                        fe.rank=strtol(s+1,NULL,10);
-                }
-                else if(*s=='N')
-                    fe.flag=DTREE_DT_FLAG_NONE;
-            }
-        }
-    
-        if(!fe.flag)
-            fe.flag=DTREE_DT_FLAG_NONE;
-
-        if(fe.cparam)
-        {
-            for(s=fe.cparam;*s;s++)
-            {
-                if(*s==':')
-                {
-                    *s='\0';
-
-                    fe.cparam_len=s-fe.cparam;
-
-                    fe.dir=strtol(s+1,NULL,10);
-                }
-            }
-        }
-
-        if(fe.pos>DTREE_S_BE_POS)
-            fe.pos=DTREE_S_MAX_POS;
-        if(fe.rank>DTREE_S_MAX_RANK)
-            fe.rank=DTREE_S_MAX_RANK;
-        if(fe.dir<DTREE_S_MIN_DIR)
-            fe.dir=DTREE_S_MIN_DIR;
-        else if(fe.dir>DTREE_S_MAX_DIR)
-            fe.dir=DTREE_S_MAX_DIR;
-
-        if(*fe.pattern==DTREE_PATTERN_BEGIN)
-        {
-            fe.pos=1;
-            fe.pattern++;
-            fe.pattern_len--;
-        }
-
-        if(*(fe.pattern+fe.pattern_len-1)==DTREE_PATTERN_END && *(fe.pattern+fe.pattern_len-2)!=DTREE_PATTERN_ESCAPE)
-        {
-            if(fe.pos==1)
-                fe.pos=DTREE_S_BE_POS;
-            else
-                fe.pos=DTREE_S_MAX_POS;
-
-            *(fe.pattern+fe.pattern_len-1)='\0';
-            fe.pattern_len--;
-        }
-
-        dtree_printd(DTREE_PRINT_INITDTREE,
-                "LOAD: line dump: pattern: '%s':%zu id: '%s':%zu type: '%s' flag: %ud cparam: '%s':%zu prd: %d,%d,%d\nKVS",
-                fe.pattern,fe.pattern_len,fe.id,fe.id_len,fe.type,fe.flag,fe.cparam,fe.cparam_len,fe.pos,fe.rank,fe.dir);
-        for(i=0;i<fe.count;i++)
-            dtree_printd(DTREE_PRINT_INITDTREE,",'%s':%zu='%s':%zu",fe.p[i].key,fe.p[i].key_len,fe.p[i].value,fe.p[i].val_len);
-        dtree_printd(DTREE_PRINT_INITDTREE,"\n");
-        
-        //look for this entry
-        kvd=(dclass_keyvalue*)dtree_get(&ids,fe.id,0);
-        
-        if(!kvd)
-        {
-            kvd=(dclass_keyvalue*)dtree_alloc_mem(h,sizeof(dclass_keyvalue));
-            
-            if(!kvd)
-                goto lerror;
-            
-            //populate kvd
-            kvd->id=dtree_alloc_string(h,fe.id,fe.id_len);
-
-            memset(&entry,0,sizeof(dtree_dt_add_entry));
-
-            entry.data=kvd;
-            
-            if(dtree_add_entry(&ids,kvd->id,&entry)<0)
-                goto lerror;
-            
-            dtree_printd(DTREE_PRINT_INITDTREE,"IDS: Successful add: '%s'\n",kvd->id);
-        }
-        
-        //copy kvs
-        if(fe.count && !kvd->size)
-        {
-            if(fe.count!=keys_size)
-            {
-                keys_size=0;
-                keys=NULL;
-            }
-            
-            if(keys)
-            {
-                for(i=0;i<fe.count;i++)
-                {
-                    for(j=0;j<keys_size;j++)
-                    {
-                        if(!strcasecmp(fe.p[i].key,keys[j]))
-                            break;
-                    }
-                    
-                    if(j>=keys_size)
-                    {   
-                        keys_size=0;
-                        keys=NULL;
-                        
-                        break;
-                    }
-                }
-            }
-            
-            if(!keys)
-            {
-                dtree_printd(DTREE_PRINT_INITDTREE,"LOAD: allocating new keys count: %d\n",fe.count);
-                
-                keys=(char**)dtree_alloc_mem(h,fe.count*sizeof(char*));
-                
-                if(!keys)
-                    goto lerror;
-                
-                keys_size=fe.count;
-                
-                for(i=0;i<fe.count;i++)
-                    keys[i]=dtree_alloc_string(h,fe.p[i].key,fe.p[i].key_len);
-            }
-
-            kvd->keys=(const char**)keys;
-
-            kvd->size=fe.count;
-
-            kvd->values=(const char**)dtree_alloc_mem(h,kvd->size*sizeof(char*));
-            
-            if(!kvd->values)
-                goto lerror;
-            
-            for(i=0;i<kvd->size;i++)
-            {
-                if(fe.p[i].value)
-                    kvd->values[i]=dtree_alloc_string(h,fe.p[i].value,fe.p[i].val_len);
-            }
-        }
-        
-        cparam=NULL;
-        
-        //lookup cparam
-        if(fe.cparam && *fe.cparam)
-        {
-            dtree_printd(DTREE_PRINT_INITDTREE,"LOAD: cparam detected: '%s':%d\n",fe.cparam,fe.dir);
-            
-            cparam=(dclass_keyvalue*)dtree_get(&ids,fe.cparam,0);
-            
-            //add cparam
-            if(!cparam)
-            {
-                cparam=(dclass_keyvalue*)dtree_alloc_mem(h,sizeof(dclass_keyvalue));
-            
-                if(!cparam)
-                    goto lerror;
-
-                //populate kvd
-                cparam->id=dtree_alloc_string(h,fe.cparam,fe.cparam_len);
-
-                memset(&entry,0,sizeof(dtree_dt_add_entry));
-
-                entry.data=cparam;
-            
-                if(dtree_add_entry(&ids,cparam->id,&entry)<0)
-                    goto lerror;
-
-                dtree_printd(DTREE_PRINT_INITDTREE,"IDS: Successful add: '%s'\n",cparam->id);
-            }
-        }
-        
-        memset(&entry,0,sizeof(dtree_dt_add_entry));
-
-        entry.data=kvd;
-        entry.flags=fe.flag;
-        entry.param=cparam;
-        entry.pos=fe.pos;
-        entry.rank=fe.rank;
-        entry.dir=fe.dir;
-
-        //add the entry
-        ret=dtree_add_entry(h,fe.pattern,&entry);
-        
-        if(ret<0)
-            goto lerror;
-        else if(ret>0)
-            dtree_printd(DTREE_PRINT_INITDTREE,"LOAD: Successful add, nodes: %u, size: %lu\n",
-                    h->node_count,h->size);
-        
-#if DTREE_PERF_WALKING
-        if(!(lines%10))
-        {
-            total=high=low=0;
-            for(i=0;i<5;i++)
-            {
-                dtree_gettime(&startn);
-                lret=dtree_print(h,NULL);
-                dtree_gettime(&endn);
-                dtree_timersubn(&endn,&startn,&diffn);
-                val=(diffn.tv_sec*1000*1000*1000)+diffn.tv_nsec;
-                if(diffn.tv_nsec==0 && diffn.tv_sec==0)
-                {
-                    i--;
-                    continue;
-                }
-                if(val>high)
-                    high=val;
-                if(!i || val<low)
-                    low=val;
-                total+=val;
-            }
-            total=(total-high-low)/3;
-            printf("walk tree: %ld tokens %zu nodes time: %lds %ldms %ldus %ldns\n",
-                    lret,h->node_count,total/(1000*1000*1000),total/1000000%1000,total/1000%1000,total%1000);
-        }
-#endif
-    }
-    
-    dtree_free(&ids);
-    fclose(f);
-
-    if(!di->error.id || !strcmp(DTREE_M_SERROR,di->error.id)) {
-        if(DTREE_M_LOOKUP_CACHE && h->dc_cache[0])
-            di->error.id=h->dc_cache[0];
-    }
-    
-    return lines;
-    
-lerror:
-                    
-    dtree_free(h);
-    dtree_free(&ids);
-    fclose(f);
-    
+  if (!(f = fopen(path, "r"))) {
+    fprintf(stderr, "DTREE: cannot open '%s'\n", path);
     return -1;
+  }
+
+  // traverse the loadfile
+  while ((buf[sizeof(buf) - 2] = '\n') && (p = fgets(buf, sizeof(buf), f))) {
+    lines++;
+
+    // overflow
+    if (buf[sizeof(buf) - 2] != '\n' && buf[sizeof(buf) - 2]) {
+      dtree_printd(DTREE_PRINT_INITDTREE,
+                   "LOAD: overflow detected on line %d\n", lines);
+
+      do {
+        buf[sizeof(buf) - 2] = '\n';
+
+        if (!fgets(buf, sizeof(buf), f))
+          break;
+      } while (buf[sizeof(buf) - 2] != '\n' && buf[sizeof(buf) - 2]);
+
+      continue;
+    }
+
+    if (*buf == '#') {
+      switch (*++p) {
+      // string order is being forced here
+      case '!':
+        for (++p, s = p; *p; p++) {
+          if (*p == ',' || !*(p + 1)) {
+            *p = '\0';
+            s = dtree_alloc_string(h, s, p - s);
+            dtree_printd(DTREE_PRINT_INITDTREE, "INIT FORCE string: '%s'\n", s);
+
+            kvd =
+                (dclass_keyvalue *)dtree_alloc_mem(h, sizeof(dclass_keyvalue));
+
+            if (!kvd)
+              goto lerror;
+
+            kvd->id = s;
+
+            memset(&entry, 0, sizeof(dtree_dt_add_entry));
+
+            entry.data = kvd;
+
+            if (dtree_add_entry(&ids, kvd->id, &entry) < 0)
+              goto lerror;
+
+            dtree_printd(DTREE_PRINT_INITDTREE, "IDS: Successful add: '%s'\n",
+                         kvd->id);
+
+            s = (p + 1);
+          }
+        }
+        break;
+      // index params
+      case '$':
+        p++;
+        if (!strncasecmp(p, "partial", 6)) {
+          h->sflags |= DTREE_S_FLAG_PARTIAL;
+          dtree_printd(DTREE_PRINT_INITDTREE, "INIT FORCE: partial\n");
+        } else if (!strncasecmp(p, "regex", 5)) {
+          h->sflags |= DTREE_S_FLAG_REGEX;
+          dtree_printd(DTREE_PRINT_INITDTREE, "INIT FORCE: regex\n");
+        } else if (!strncasecmp(p, "dups", 4)) {
+          h->sflags |= DTREE_S_FLAG_DUPS;
+          dtree_printd(DTREE_PRINT_INITDTREE, "INIT FORCE: dups\n");
+        } else if (!strncasecmp(p, "notrim", 6)) {
+          h->sflags |= DTREE_S_FLAG_NOTRIM;
+          dtree_printd(DTREE_PRINT_INITDTREE, "INIT FORCE: notrim\n");
+        }
+        break;
+      // kv error id
+      case '@':
+        p++;
+        for (s = p; *p; p++) {
+          if (*p == '\n')
+            break;
+        }
+        *p = '\0';
+        di->error.id = dtree_alloc_string(h, s, p - s + 1);
+      // comment
+      default:
+        if (!h->comment) {
+          if (*p == ' ')
+            p++;
+          for (s = p; *p; p++) {
+            if (*p == '\n')
+              break;
+          }
+          *p = '\0';
+          h->comment = dtree_alloc_mem(h, (p - s + 1) * sizeof(char));
+          if (h->comment)
+            strncpy(h->comment, s, p - s);
+        }
+        break;
+      }
+      continue;
+    }
+
+    memset(&fe, 0, sizeof(fe));
+
+    // parse the line
+    dclass_parse_fentry(buf, &fe, h->sflags & DTREE_S_FLAG_NOTRIM);
+
+    if (!fe.id) {
+      dtree_printd(DTREE_PRINT_INITDTREE, "LOAD: bad line detected: '%s':%d\n",
+                   buf, lines);
+      continue;
+    }
+
+    if (fe.type) {
+      for (s = fe.type; *s; s++) {
+        if (*s == ':') {
+          s++;
+          fe.pos = strtol(s, NULL, 10);
+          break;
+        } else if (fe.flag)
+          continue;
+        else if (*s == 'S')
+          fe.flag = DTREE_DT_FLAG_STRONG;
+        else if (*s == 'W') {
+          fe.flag = DTREE_DT_FLAG_WEAK;
+          if (*(s + 1) >= '0' && *(s + 1) <= '9')
+            fe.rank = strtol(s + 1, NULL, 10);
+        } else if (*s == 'B')
+          fe.flag = DTREE_DT_FLAG_BCHAIN;
+        else if (*s == 'C') {
+          fe.flag = DTREE_DT_FLAG_CHAIN;
+          if (*(s + 1) >= '0' && *(s + 1) <= '9')
+            fe.rank = strtol(s + 1, NULL, 10);
+        } else if (*s == 'N')
+          fe.flag = DTREE_DT_FLAG_NONE;
+      }
+    }
+
+    if (!fe.flag)
+      fe.flag = DTREE_DT_FLAG_NONE;
+
+    if (fe.cparam) {
+      for (s = fe.cparam; *s; s++) {
+        if (*s == ':') {
+          *s = '\0';
+
+          fe.cparam_len = s - fe.cparam;
+
+          fe.dir = strtol(s + 1, NULL, 10);
+        }
+      }
+    }
+
+    if (fe.pos > DTREE_S_BE_POS)
+      fe.pos = DTREE_S_MAX_POS;
+    if (fe.rank > DTREE_S_MAX_RANK)
+      fe.rank = DTREE_S_MAX_RANK;
+    if (fe.dir < DTREE_S_MIN_DIR)
+      fe.dir = DTREE_S_MIN_DIR;
+    else if (fe.dir > DTREE_S_MAX_DIR)
+      fe.dir = DTREE_S_MAX_DIR;
+
+    if (*fe.pattern == DTREE_PATTERN_BEGIN) {
+      fe.pos = 1;
+      fe.pattern++;
+      fe.pattern_len--;
+    }
+
+    if (*(fe.pattern + fe.pattern_len - 1) == DTREE_PATTERN_END &&
+        *(fe.pattern + fe.pattern_len - 2) != DTREE_PATTERN_ESCAPE) {
+      if (fe.pos == 1)
+        fe.pos = DTREE_S_BE_POS;
+      else
+        fe.pos = DTREE_S_MAX_POS;
+
+      *(fe.pattern + fe.pattern_len - 1) = '\0';
+      fe.pattern_len--;
+    }
+
+    dtree_printd(DTREE_PRINT_INITDTREE,
+                 "LOAD: line dump: pattern: '%s':%zu id: '%s':%zu type: '%s' "
+                 "flag: %ud cparam: '%s':%zu prd: %d,%d,%d\nKVS",
+                 fe.pattern, fe.pattern_len, fe.id, fe.id_len, fe.type, fe.flag,
+                 fe.cparam, fe.cparam_len, fe.pos, fe.rank, fe.dir);
+    for (i = 0; i < fe.count; i++)
+      dtree_printd(DTREE_PRINT_INITDTREE, ",'%s':%zu='%s':%zu", fe.p[i].key,
+                   fe.p[i].key_len, fe.p[i].value, fe.p[i].val_len);
+    dtree_printd(DTREE_PRINT_INITDTREE, "\n");
+
+    // look for this entry
+    kvd = (dclass_keyvalue *)dtree_get(&ids, fe.id, 0);
+
+    if (!kvd) {
+      kvd = (dclass_keyvalue *)dtree_alloc_mem(h, sizeof(dclass_keyvalue));
+
+      if (!kvd)
+        goto lerror;
+
+      // populate kvd
+      kvd->id = dtree_alloc_string(h, fe.id, fe.id_len);
+
+      memset(&entry, 0, sizeof(dtree_dt_add_entry));
+
+      entry.data = kvd;
+
+      if (dtree_add_entry(&ids, kvd->id, &entry) < 0)
+        goto lerror;
+
+      dtree_printd(DTREE_PRINT_INITDTREE, "IDS: Successful add: '%s'\n",
+                   kvd->id);
+    }
+
+    // copy kvs
+    if (fe.count && !kvd->size) {
+      if (fe.count != keys_size) {
+        keys_size = 0;
+        keys = NULL;
+      }
+
+      if (keys) {
+        for (i = 0; i < fe.count; i++) {
+          for (j = 0; j < keys_size; j++) {
+            if (!strcasecmp(fe.p[i].key, keys[j]))
+              break;
+          }
+
+          if (j >= keys_size) {
+            keys_size = 0;
+            keys = NULL;
+
+            break;
+          }
+        }
+      }
+
+      if (!keys) {
+        dtree_printd(DTREE_PRINT_INITDTREE,
+                     "LOAD: allocating new keys count: %d\n", fe.count);
+
+        keys = (char **)dtree_alloc_mem(h, fe.count * sizeof(char *));
+
+        if (!keys)
+          goto lerror;
+
+        keys_size = fe.count;
+
+        for (i = 0; i < fe.count; i++)
+          keys[i] = dtree_alloc_string(h, fe.p[i].key, fe.p[i].key_len);
+      }
+
+      kvd->keys = (const char **)keys;
+
+      kvd->size = fe.count;
+
+      kvd->values =
+          (const char **)dtree_alloc_mem(h, kvd->size * sizeof(char *));
+
+      if (!kvd->values)
+        goto lerror;
+
+      for (i = 0; i < kvd->size; i++) {
+        if (fe.p[i].value)
+          kvd->values[i] =
+              dtree_alloc_string(h, fe.p[i].value, fe.p[i].val_len);
+      }
+    }
+
+    cparam = NULL;
+
+    // lookup cparam
+    if (fe.cparam && *fe.cparam) {
+      dtree_printd(DTREE_PRINT_INITDTREE, "LOAD: cparam detected: '%s':%d\n",
+                   fe.cparam, fe.dir);
+
+      cparam = (dclass_keyvalue *)dtree_get(&ids, fe.cparam, 0);
+
+      // add cparam
+      if (!cparam) {
+        cparam = (dclass_keyvalue *)dtree_alloc_mem(h, sizeof(dclass_keyvalue));
+
+        if (!cparam)
+          goto lerror;
+
+        // populate kvd
+        cparam->id = dtree_alloc_string(h, fe.cparam, fe.cparam_len);
+
+        memset(&entry, 0, sizeof(dtree_dt_add_entry));
+
+        entry.data = cparam;
+
+        if (dtree_add_entry(&ids, cparam->id, &entry) < 0)
+          goto lerror;
+
+        dtree_printd(DTREE_PRINT_INITDTREE, "IDS: Successful add: '%s'\n",
+                     cparam->id);
+      }
+    }
+
+    memset(&entry, 0, sizeof(dtree_dt_add_entry));
+
+    entry.data = kvd;
+    entry.flags = fe.flag;
+    entry.param = cparam;
+    entry.pos = fe.pos;
+    entry.rank = fe.rank;
+    entry.dir = fe.dir;
+
+    // add the entry
+    ret = dtree_add_entry(h, fe.pattern, &entry);
+
+    if (ret < 0)
+      goto lerror;
+    else if (ret > 0)
+      dtree_printd(DTREE_PRINT_INITDTREE,
+                   "LOAD: Successful add, nodes: %u, size: %lu\n",
+                   h->node_count, h->size);
+
+#if DTREE_PERF_WALKING
+    if (!(lines % 10)) {
+      total = high = low = 0;
+      for (i = 0; i < 5; i++) {
+        dtree_gettime(&startn);
+        lret = dtree_print(h, NULL);
+        dtree_gettime(&endn);
+        dtree_timersubn(&endn, &startn, &diffn);
+        val = (diffn.tv_sec * 1000 * 1000 * 1000) + diffn.tv_nsec;
+        if (diffn.tv_nsec == 0 && diffn.tv_sec == 0) {
+          i--;
+          continue;
+        }
+        if (val > high)
+          high = val;
+        if (!i || val < low)
+          low = val;
+        total += val;
+      }
+      total = (total - high - low) / 3;
+      printf("walk tree: %ld tokens %zu nodes time: %lds %ldms %ldus %ldns\n",
+             lret, h->node_count, total / (1000 * 1000 * 1000),
+             total / 1000000 % 1000, total / 1000 % 1000, total % 1000);
+    }
+#endif
+  }
+
+  dtree_free(&ids);
+  fclose(f);
+
+  if (!di->error.id || !strcmp(DTREE_M_SERROR, di->error.id)) {
+    if (DTREE_M_LOOKUP_CACHE && h->dc_cache[0])
+      di->error.id = h->dc_cache[0];
+  }
+
+  return lines;
+
+lerror:
+
+  dtree_free(h);
+  dtree_free(&ids);
+  fclose(f);
+
+  return -1;
 }
 
-//parses a line into a file_entry
-static void dclass_parse_fentry(char *buf,dtree_file_entry *fe,int notrim)
-{
-    int count=0;
-    char sep;
-    char *p;
-    char *t;
-    char *e;
-    char *key=NULL;
-    size_t klen=0;
-    size_t len=0;
-    
-    for(p=buf;*p;p++)
-    {
-        //start
-        e=t=p;
-        
-        //end
-        for(;*p;p++)
-        {
-            e=p;
-            len=p-t;
+// parses a line into a file_entry
+static void dclass_parse_fentry(char *buf, dtree_file_entry *fe, int notrim) {
+  int count = 0;
+  char sep;
+  char *p;
+  char *t;
+  char *e;
+  char *key = NULL;
+  size_t klen = 0;
+  size_t len = 0;
 
-            if((*p==';' && count<4) || ((*p==',' || *p=='=') && count>=4) || *p=='\n')
-            {
-                if(!notrim)
-                {
-                    while((*t==' ' || *t=='\t') && t<p)
-                        t++;
-                    while((*(p-1)==' ' || *(p-1)=='\t') && p>t)
-                        p--;
+  for (p = buf; *p; p++) {
+    // start
+    e = t = p;
 
-                    len=p-t;
-                }
-                if(*t==DTREE_PATTERN_DQUOTE && p>(t+1) && *(p-1)==DTREE_PATTERN_DQUOTE && *(p-2)!=DTREE_PATTERN_ESCAPE)
-                {
-                    t++;
-                    *(p-1)='\0';
-                    len-=2;
-                }
-                else if(*t==DTREE_PATTERN_DQUOTE && *p!='\n')
-                {
-                    if(!notrim)
-                        p=e;
-                    continue;
-                }
-                
-                break;
-            }
+    // end
+    for (; *p; p++) {
+      e = p;
+      len = p - t;
+
+      if ((*p == ';' && count < 4) ||
+          ((*p == ',' || *p == '=') && count >= 4) || *p == '\n') {
+        if (!notrim) {
+          while ((*t == ' ' || *t == '\t') && t < p)
+            t++;
+          while ((*(p - 1) == ' ' || *(p - 1) == '\t') && p > t)
+            p--;
+
+          len = p - t;
         }
-        
-        sep=*p;
-
-        if(!notrim)
-            sep=*e;
-
-        *p='\0';
-
-        p=e;
-
-        if(strlen(t)!=len)
-            dtree_printd(DTREE_PRINT_INITDTREE,"LOAD: ERROR: '%s' != %zu\n",t,len);
-
-        if(!count)
-        {
-            fe->pattern=t;
-            fe->pattern_len=len;
+        if (*t == DTREE_PATTERN_DQUOTE && p > (t + 1) &&
+            *(p - 1) == DTREE_PATTERN_DQUOTE &&
+            *(p - 2) != DTREE_PATTERN_ESCAPE) {
+          t++;
+          *(p - 1) = '\0';
+          len -= 2;
+        } else if (*t == DTREE_PATTERN_DQUOTE && *p != '\n') {
+          if (!notrim)
+            p = e;
+          continue;
         }
-        else if(count==1)
-        {
-            fe->id=t;
-            fe->id_len=len;
-        }
-        else if(count==2)
-            fe->type=t;
-        else if(count==3)
-        {
-            fe->cparam=t;
-            fe->cparam_len=len;
-        }
-        else if(count>=4)
-        {
-            if(!key)
-            {
-                key=t;
-                klen=len;
-                
-                if(sep==',')
-                {
-                    t=NULL;
-                    len=0;
-                }
-                else
-                    continue;
-            }
-            
-            fe->p[fe->count].key=key;
-            fe->p[fe->count].key_len=klen;
-            fe->p[fe->count].value=t;
-            fe->p[fe->count].val_len=len;
-            
-            fe->count++;
 
-            if(fe->count>=DTREE_DATA_MKEYS)
-                break;
-            
-            key=NULL;
-        }
-        
-        count++;
+        break;
+      }
     }
+
+    sep = *p;
+
+    if (!notrim)
+      sep = *e;
+
+    *p = '\0';
+
+    p = e;
+
+    if (strlen(t) != len)
+      dtree_printd(DTREE_PRINT_INITDTREE, "LOAD: ERROR: '%s' != %zu\n", t, len);
+
+    if (!count) {
+      fe->pattern = t;
+      fe->pattern_len = len;
+    } else if (count == 1) {
+      fe->id = t;
+      fe->id_len = len;
+    } else if (count == 2)
+      fe->type = t;
+    else if (count == 3) {
+      fe->cparam = t;
+      fe->cparam_len = len;
+    } else if (count >= 4) {
+      if (!key) {
+        key = t;
+        klen = len;
+
+        if (sep == ',') {
+          t = NULL;
+          len = 0;
+        } else
+          continue;
+      }
+
+      fe->p[fe->count].key = key;
+      fe->p[fe->count].key_len = klen;
+      fe->p[fe->count].value = t;
+      fe->p[fe->count].val_len = len;
+
+      fe->count++;
+
+      if (fe->count >= DTREE_DATA_MKEYS)
+        break;
+
+      key = NULL;
+    }
+
+    count++;
+  }
 }
 
-//writes a dtree file
-int dclass_write_file(const dclass_index *di,const char *outFile)
-{
-    int lines=0;
-    unsigned int i;
-    char buf[DTREE_DATA_BUFLEN];
-    FILE *f;
-    const dtree_dt_index *h=&di->dti;
-    
-    if(!(f=fopen(outFile,"w")))
-    {
-        fprintf(stderr,"DTREE: cannot open '%s'\n",outFile);
-        return -1;
-    }
-    
-    if(h->comment)
-    {
-        fputs("# ",f);
-        fputs(h->comment,f);
-        fputc('\n',f);
-    }
-    else
-        fputs("# dtree dump\n",f);
-    
-    if(h->sflags & DTREE_S_FLAG_PARTIAL)
-        fputs("#$partial\n",f);
-    
-    if(h->sflags & DTREE_S_FLAG_REGEX)
-        fputs("#$regex\n",f);
-    
-    if(h->sflags & DTREE_S_FLAG_DUPS)
-        fputs("#$dups\n",f);
-    
-    if(di->error.id && strcmp(DTREE_M_SERROR,di->error.id)) {
-        fputs("#@",f);
-        fputs(di->error.id,f);
-        fputc('\n',f);
-    }
+// writes a dtree file
+int dclass_write_file(const dclass_index *di, const char *outFile) {
+  int lines = 0;
+  unsigned int i;
+  char buf[DTREE_DATA_BUFLEN];
+  FILE *f;
+  const dtree_dt_index *h = &di->dti;
 
-    //dump cache
-    if(h->dc_cache[0])
-    {
-        fputs("#!",f);
-        for(i=0;h->dc_cache[i] && i<DTREE_M_LOOKUP_CACHE;i++)
-        {
-            if(i && !(i%8))
-                fputs("\n#!",f);
-            else if(i)
-                fputc(',',f);
-            fputs(h->dc_cache[i],f);
-        }
-        fputc('\n',f);
+  if (!(f = fopen(outFile, "w"))) {
+    fprintf(stderr, "DTREE: cannot open '%s'\n", outFile);
+    return -1;
+  }
+
+  if (h->comment) {
+    fputs("# ", f);
+    fputs(h->comment, f);
+    fputc('\n', f);
+  } else
+    fputs("# dtree dump\n", f);
+
+  if (h->sflags & DTREE_S_FLAG_PARTIAL)
+    fputs("#$partial\n", f);
+
+  if (h->sflags & DTREE_S_FLAG_REGEX)
+    fputs("#$regex\n", f);
+
+  if (h->sflags & DTREE_S_FLAG_DUPS)
+    fputs("#$dups\n", f);
+
+  if (di->error.id && strcmp(DTREE_M_SERROR, di->error.id)) {
+    fputs("#@", f);
+    fputs(di->error.id, f);
+    fputc('\n', f);
+  }
+
+  // dump cache
+  if (h->dc_cache[0]) {
+    fputs("#!", f);
+    for (i = 0; h->dc_cache[i] && i < DTREE_M_LOOKUP_CACHE; i++) {
+      if (i && !(i % 8))
+        fputs("\n#!", f);
+      else if (i)
+        fputc(',', f);
+      fputs(h->dc_cache[i], f);
     }
-    
-    for(i=0;h->head && i<DTREE_HASH_NCOUNT;i++)
-        lines+=dclass_write_tree(h,DTREE_DT_GETPP(h,h->head->nodes[i]),buf,0,f);
-    
-    fclose(f);
-    
-    return lines;
+    fputc('\n', f);
+  }
+
+  for (i = 0; h->head && i < DTREE_HASH_NCOUNT; i++)
+    lines +=
+        dclass_write_tree(h, DTREE_DT_GETPP(h, h->head->nodes[i]), buf, 0, f);
+
+  fclose(f);
+
+  return lines;
 }
 
-static long dclass_write_tree(const dtree_dt_index *h,const dtree_dt_node *n,char *path,int depth,FILE *f)
-{
-    unsigned int i;
-    long tot=0;
-    packed_ptr pp;
-    const dtree_dt_node *dupn;
-    
-    if(!n || !n->curr || depth>(DTREE_DATA_BUFLEN-1))
-        return 0;
-    
-    if(h->sflags & DTREE_S_FLAG_REGEX)
-    {
-        switch(n->data)
-        {
-            case DTREE_PATTERN_ANY:
-                pp=n->prev;
-                dupn=DTREE_DT_GETPP(h,pp);
-                i=dtree_hash_char(n->data);
-                if(i==DTREE_HASH_ANY || (pp && dupn->nodes[i]!=n->curr))
-                    break;
-            case DTREE_PATTERN_OPTIONAL:
-            case DTREE_PATTERN_SET_S:
-            case DTREE_PATTERN_SET_E:
-            case DTREE_PATTERN_GROUP_S:
-            case DTREE_PATTERN_GROUP_E:
-            case DTREE_PATTERN_ESCAPE:
-            case DTREE_PATTERN_DQUOTE:
-                path[depth]=DTREE_PATTERN_ESCAPE;
-                depth++;
-        }
-    }
+static long dclass_write_tree(const dtree_dt_index *h, const dtree_dt_node *n,
+                              char *path, int depth, FILE *f) {
+  unsigned int i;
+  long tot = 0;
+  packed_ptr pp;
+  const dtree_dt_node *dupn;
 
-    path[depth]=n->data;
-    path[depth+1]='\0';
-    
-    if(n->flags & DTREE_DT_FLAG_TOKEN)
-    {
-        dclass_write_node(n,path,f);
-        
-        tot++;
-    }
-    
-    pp=n->dup;
-    dupn=DTREE_DT_GETPP(h,pp);
-    
-    while(pp)
-    {
-        dclass_write_node(dupn,path,f);
-        
-        tot++;
-        
-        pp=dupn->dup;
-        dupn=DTREE_DT_GETPP(h,pp);
-    }
-    
-    for(i=0;i<DTREE_HASH_NCOUNT;i++)
-    {
-        if(n->nodes[i])
-            tot+=dclass_write_tree(h,DTREE_DT_GETPP(h,n->nodes[i]),path,depth+1,f);
-    }
-    
-    path[depth]='\0';
+  if (!n || !n->curr || depth > (DTREE_DATA_BUFLEN - 1))
+    return 0;
 
-    if(path[depth-1]==DTREE_PATTERN_ESCAPE)
-        path[depth-1]='\0';
-    
-    return tot;
+  if (h->sflags & DTREE_S_FLAG_REGEX) {
+    switch (n->data) {
+    case DTREE_PATTERN_ANY:
+      pp = n->prev;
+      dupn = DTREE_DT_GETPP(h, pp);
+      i = dtree_hash_char(n->data);
+      if (i == DTREE_HASH_ANY || (pp && dupn->nodes[i] != n->curr))
+        break;
+    case DTREE_PATTERN_OPTIONAL:
+    case DTREE_PATTERN_SET_S:
+    case DTREE_PATTERN_SET_E:
+    case DTREE_PATTERN_GROUP_S:
+    case DTREE_PATTERN_GROUP_E:
+    case DTREE_PATTERN_ESCAPE:
+    case DTREE_PATTERN_DQUOTE:
+      path[depth] = DTREE_PATTERN_ESCAPE;
+      depth++;
+    }
+  }
+
+  path[depth] = n->data;
+  path[depth + 1] = '\0';
+
+  if (n->flags & DTREE_DT_FLAG_TOKEN) {
+    dclass_write_node(n, path, f);
+
+    tot++;
+  }
+
+  pp = n->dup;
+  dupn = DTREE_DT_GETPP(h, pp);
+
+  while (pp) {
+    dclass_write_node(dupn, path, f);
+
+    tot++;
+
+    pp = dupn->dup;
+    dupn = DTREE_DT_GETPP(h, pp);
+  }
+
+  for (i = 0; i < DTREE_HASH_NCOUNT; i++) {
+    if (n->nodes[i])
+      tot += dclass_write_tree(h, DTREE_DT_GETPP(h, n->nodes[i]), path,
+                               depth + 1, f);
+  }
+
+  path[depth] = '\0';
+
+  if (path[depth - 1] == DTREE_PATTERN_ESCAPE)
+    path[depth - 1] = '\0';
+
+  return tot;
 }
 
-static void dclass_write_node(const dtree_dt_node *n,char *path,FILE *f)
-{
-    int i;
-    dclass_keyvalue *s;
-    
-    s=(dclass_keyvalue*)n->payload;
-    
-    fputc(DTREE_PATTERN_DQUOTE,f);
-    
-    fputs(path,f);
-    
-    fputc(DTREE_PATTERN_DQUOTE,f);
-    fputc(';',f);
-    fputc(DTREE_PATTERN_DQUOTE,f);
-    
-    fputs(s->id,f);
-    
-    fputc(DTREE_PATTERN_DQUOTE,f);
-    fputc(';',f);
+static void dclass_write_node(const dtree_dt_node *n, char *path, FILE *f) {
+  int i;
+  dclass_keyvalue *s;
 
-    if(n->flags & DTREE_DT_FLAG_STRONG)
-        fputc('S',f);
-    else if(n->flags & DTREE_DT_FLAG_WEAK)
-    {
-        fputc('W',f);
-        if(n->rank)
-            fprintf(f,"%hd",(short int)n->rank);
-    }
-    else if(n->flags & DTREE_DT_FLAG_BCHAIN)
-        fputc('B',f);
-    else if(n->flags & DTREE_DT_FLAG_CHAIN)
-    {
-        fputc('C',f);
-        if(n->rank)
-            fprintf(f,"%hd",(short int)n->rank);
-    }
-    else
-        fputc('N',f);
-    
-    if(n->pos)
-        fprintf(f,":%hd",(short int)n->pos);
+  s = (dclass_keyvalue *)n->payload;
 
-    fputc(';',f);
-    
-    if(n->cparam)
-    {
-        fputc(DTREE_PATTERN_DQUOTE,f);
-        fputs(((dclass_keyvalue*)n->cparam)->id,f);
-        if(n->dir)
-            fprintf(f,":%d",n->dir);
-        fputc(DTREE_PATTERN_DQUOTE,f);
+  fputc(DTREE_PATTERN_DQUOTE, f);
+
+  fputs(path, f);
+
+  fputc(DTREE_PATTERN_DQUOTE, f);
+  fputc(';', f);
+  fputc(DTREE_PATTERN_DQUOTE, f);
+
+  fputs(s->id, f);
+
+  fputc(DTREE_PATTERN_DQUOTE, f);
+  fputc(';', f);
+
+  if (n->flags & DTREE_DT_FLAG_STRONG)
+    fputc('S', f);
+  else if (n->flags & DTREE_DT_FLAG_WEAK) {
+    fputc('W', f);
+    if (n->rank)
+      fprintf(f, "%hd", (short int)n->rank);
+  } else if (n->flags & DTREE_DT_FLAG_BCHAIN)
+    fputc('B', f);
+  else if (n->flags & DTREE_DT_FLAG_CHAIN) {
+    fputc('C', f);
+    if (n->rank)
+      fprintf(f, "%hd", (short int)n->rank);
+  } else
+    fputc('N', f);
+
+  if (n->pos)
+    fprintf(f, ":%hd", (short int)n->pos);
+
+  fputc(';', f);
+
+  if (n->cparam) {
+    fputc(DTREE_PATTERN_DQUOTE, f);
+    fputs(((dclass_keyvalue *)n->cparam)->id, f);
+    if (n->dir)
+      fprintf(f, ":%d", n->dir);
+    fputc(DTREE_PATTERN_DQUOTE, f);
+  }
+
+  fputc(';', f);
+
+  for (i = 0; i < s->size; i++) {
+    if (i)
+      fputc(',', f);
+    fputc(DTREE_PATTERN_DQUOTE, f);
+    fputs(s->keys[i], f);
+    fputc(DTREE_PATTERN_DQUOTE, f);
+    if (s->values[i]) {
+      fputc('=', f);
+      fputc(DTREE_PATTERN_DQUOTE, f);
+      fputs(s->values[i], f);
+      fputc(DTREE_PATTERN_DQUOTE, f);
     }
-    
-    fputc(';',f);
-    
-    for(i=0;i<s->size;i++)
-    {
-        if(i)
-            fputc(',',f);
-        fputc(DTREE_PATTERN_DQUOTE,f);
-        fputs(s->keys[i],f);
-        fputc(DTREE_PATTERN_DQUOTE,f);
-        if(s->values[i])
-        {
-            fputc('=',f);
-            fputc(DTREE_PATTERN_DQUOTE,f);
-            fputs(s->values[i],f);
-            fputc(DTREE_PATTERN_DQUOTE,f);
-        }
-    }
-    
-    fputc('\n',f);
+  }
+
+  fputc('\n', f);
 }

--- a/src/devicemap_client.h
+++ b/src/devicemap_client.h
@@ -13,50 +13,34 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
-
 
 #ifndef _DCLASS_DEVICEMAP_CLIENT_H
 #define _DCLASS_DEVICEMAP_CLIENT_H
 
-
-#include "dtree_client.h"
 #include "dclass_client.h"
+#include "dtree_client.h"
 
+// resource files
+#define DEVICEMAP_RSRC_DD "DeviceDataSource.xml"
+#define DEVICEMAP_RSRC_DDP "DeviceDataSourcePatch.xml"
+#define DEVICEMAP_RSRC_BD "BuilderDataSource.xml"
+#define DEVICEMAP_RSRC_BDP "BuilderDataSourcePatch.xml"
 
-//resource files
-#define DEVICEMAP_RSRC_DD     "DeviceDataSource.xml"
-#define DEVICEMAP_RSRC_DDP    "DeviceDataSourcePatch.xml"
-#define DEVICEMAP_RSRC_BD     "BuilderDataSource.xml"
-#define DEVICEMAP_RSRC_BDP    "BuilderDataSourcePatch.xml"
+#define DEVICEMAP_COMMENT                                                      \
+  "DeviceMap %s http://devicemap.apache.org/ (device detection ddr)"
 
+#define DEVICEMAP_KEYS                                                         \
+  {                                                                            \
+    "vendor", "model", "parentId", "inputDevices", "displayHeight",            \
+        "displayWidth", "device_os", "ajax_support_javascript", "is_tablet",   \
+        "is_wireless_device", "is_crawler", "is_desktop"                       \
+  }
 
-#define DEVICEMAP_COMMENT     "DeviceMap %s http://devicemap.apache.org/ (device detection ddr)"
+int devicemap_load_resources(dclass_index *, const char *);
 
+// openddr blackberry fix
+#define OPENDDR_BLKBRY_FIX 1
 
-#define DEVICEMAP_KEYS        {                            \
-                                "vendor",                  \
-                                "model",                   \
-                                "parentId",                \
-                                "inputDevices",            \
-                                "displayHeight",           \
-                                "displayWidth",            \
-                                "device_os",               \
-                                "ajax_support_javascript", \
-                                "is_tablet",               \
-                                "is_wireless_device",      \
-                                "is_crawler",              \
-                                "is_desktop"               \
-                              }
-
-
-int devicemap_load_resources(dclass_index*,const char*);
-
-
-//openddr blackberry fix
-#define OPENDDR_BLKBRY_FIX    1
-
-
-#endif	/* _DCLASS_DEVICEMAP_CLIENT_H */
-
+#endif /* _DCLASS_DEVICEMAP_CLIENT_H */

--- a/src/dtree_client.h
+++ b/src/dtree_client.h
@@ -13,242 +13,227 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
-
 
 #ifndef _DTREE_H_INCLUDED_
 #define _DTREE_H_INCLUDED_
 
-
+#include <ctype.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdarg.h>
-#include <ctype.h>
 
 #ifdef _DTREE_NO_TIMESPEC
 #define __timespec_defined 1
 #else
-#include <time.h>
 #include <sys/time.h>
+#include <time.h>
 #endif
 
 #include <stdlib.h>
 
+// logging and testing
+#define DTREE_TEST_UALOOKUP 1
+#define DTREE_PERF_WALKING 0
+#define DTREE_DEBUG_LOGGING 0
 
-//logging and testing
-#define DTREE_TEST_UALOOKUP     1
-#define DTREE_PERF_WALKING      0
-#define DTREE_DEBUG_LOGGING     0
+#define DTREE_PRINT_GENERIC (1 << 0)
+#define DTREE_PRINT_CLASSIFY (1 << 1)
+#define DTREE_PRINT_INITDTREE (1 << 2)
 
-#define DTREE_PRINT_GENERIC     (1 << 0)
-#define DTREE_PRINT_CLASSIFY    (1 << 1)
-#define DTREE_PRINT_INITDTREE   (1 << 2)
+// what messages to print, DEBUG_LOGGING needs to be enabled
+#define DTREE_PRINT_ENABLED                                                    \
+  (DTREE_PRINT_GENERIC | DTREE_PRINT_CLASSIFY | DTREE_PRINT_INITDTREE)
 
-//what messages to print, DEBUG_LOGGING needs to be enabled
-#define DTREE_PRINT_ENABLED     (DTREE_PRINT_GENERIC|DTREE_PRINT_CLASSIFY|DTREE_PRINT_INITDTREE)
-
-
-//if enabled, this packs system pointers into 16/32 bits
+// if enabled, this packs system pointers into 16/32 bits
 #ifndef DTREE_DT_PACKED
-#define DTREE_DT_PACKED         1
+#define DTREE_DT_PACKED 1
 #endif
 
-//if PACKED is enabled, uses 16bit pointers, otherwise 32bit
+// if PACKED is enabled, uses 16bit pointers, otherwise 32bit
 #ifndef DTREE_DT_PACKED_16
-#define DTREE_DT_PACKED_16      1
+#define DTREE_DT_PACKED_16 1
 #endif
 
 #if DTREE_DT_PACKED
 
 #if DTREE_DT_PACKED_16
-//16bit pointer, 6 bits max for SLABS (max=64)
+// 16bit pointer, 6 bits max for SLABS (max=64)
 typedef unsigned short int packed_ptr;
-#define DTREE_DT_MAX_SLABS      64
+#define DTREE_DT_MAX_SLABS 64
 #else
-//32bit pointer, 22 bits max for SLABS (max=4194304)
+// 32bit pointer, 22 bits max for SLABS (max=4194304)
 typedef unsigned int packed_ptr;
-#define DTREE_DT_MAX_SLABS      4096
+#define DTREE_DT_MAX_SLABS 4096
 #endif /*DTREE_DT_PACKED_16*/
 
-#define DTREE_DT_SLAB_SIZE      1024
-#define DTREE_DT_GETPPH(PP)     ((PP)>>10)
-#define DTREE_DT_GETPPL(PP)     ((PP)&0x3FF)
-#define DTREE_DT_GETPP(H,PP)    (&((dtree_dt_node*)(H)->slabs[DTREE_DT_GETPPH(PP)])[DTREE_DT_GETPPL(PP)])
-#define DTREE_DT_GENPP(P,H,L)   (((H)<<10)|(L))
+#define DTREE_DT_SLAB_SIZE 1024
+#define DTREE_DT_GETPPH(PP) ((PP) >> 10)
+#define DTREE_DT_GETPPL(PP) ((PP)&0x3FF)
+#define DTREE_DT_GETPP(H, PP)                                                  \
+  (&((dtree_dt_node *)(H)->slabs[DTREE_DT_GETPPH(PP)])[DTREE_DT_GETPPL(PP)])
+#define DTREE_DT_GENPP(P, H, L) (((H) << 10) | (L))
 
-#define DTREE_DT_PTR_TYPE       "v"
+#define DTREE_DT_PTR_TYPE "v"
 
 #else /*NOT DTREE_DT_PACKED*/
 
-//it is safe to change these values
-#define DTREE_DT_MAX_SLABS      4096
-#define DTREE_DT_SLAB_SIZE      4096
+// it is safe to change these values
+#define DTREE_DT_MAX_SLABS 4096
+#define DTREE_DT_SLAB_SIZE 4096
 
-#define DTREE_DT_GETPP(H,PP)    ((dtree_dt_node*)(PP))
-#define DTREE_DT_GENPP(P,H,L)   ((packed_ptr)(P))
+#define DTREE_DT_GETPP(H, PP) ((dtree_dt_node *)(PP))
+#define DTREE_DT_GENPP(P, H, L) ((packed_ptr)(P))
 
-#define DTREE_DT_PTR_TYPE       "n"
+#define DTREE_DT_PTR_TYPE "n"
 
 #endif /*DTREE_DT_PACKED*/
 
+#define DTREE_DT_PTR_SIZE (sizeof(packed_ptr) * 8)
 
-#define DTREE_DT_PTR_SIZE       (sizeof(packed_ptr)*8)
+// flags, constants, etc
+#define DTREE_DT_FLAG_TOKEN (1 << 0)
+#define DTREE_DT_FLAG_STRONG (1 << 1)
+#define DTREE_DT_FLAG_WEAK (1 << 2)
+#define DTREE_DT_FLAG_NONE (1 << 3)
+#define DTREE_DT_FLAG_CHAIN (1 << 4)
+#define DTREE_DT_FLAG_BCHAIN (1 << 5)
 
+#define DTREE_DT_FLAG_ACHAIN (DTREE_DT_FLAG_CHAIN | DTREE_DT_FLAG_BCHAIN)
 
-//flags, constants, etc
-#define DTREE_DT_FLAG_TOKEN     (1 << 0)
-#define DTREE_DT_FLAG_STRONG    (1 << 1)
-#define DTREE_DT_FLAG_WEAK      (1 << 2)
-#define DTREE_DT_FLAG_NONE      (1 << 3)
-#define DTREE_DT_FLAG_CHAIN     (1 << 4)
-#define DTREE_DT_FLAG_BCHAIN    (1 << 5)
+#define DTREE_S_FLAG_NONE (1 << 0)
+#define DTREE_S_FLAG_PARTIAL (1 << 1)
+#define DTREE_S_FLAG_REGEX (1 << 2)
+#define DTREE_S_FLAG_DUPS (1 << 3)
+#define DTREE_S_FLAG_NOTRIM (1 << 4)
+#define DTREE_S_MAX_CHAIN 10
+#define DTREE_S_BE_POS 255
+#define DTREE_S_MAX_POS 254
+#define DTREE_S_MAX_RANK 255
+#define DTREE_S_MIN_DIR -127
+#define DTREE_S_MAX_DIR 127
 
-#define DTREE_DT_FLAG_ACHAIN    (DTREE_DT_FLAG_CHAIN|DTREE_DT_FLAG_BCHAIN)
+#define DTREE_M_MAX_SLABS 512
+#define DTREE_M_SLAB_SIZE (1024 * 512)
+#define DTREE_M_SERROR "serror"
+#define DTREE_M_LOOKUP_CACHE 6
+#define DTREE_DATA_BUFLEN 128
+#define DTREE_DATA_MKEYS 30
+#define DTREE_DC_DISTANCE(H, S) ((int)((S) - ((char *)(H)->dc_slabs[0])))
 
-#define DTREE_S_FLAG_NONE       (1 << 0)
-#define DTREE_S_FLAG_PARTIAL    (1 << 1)
-#define DTREE_S_FLAG_REGEX      (1 << 2)
-#define DTREE_S_FLAG_DUPS       (1 << 3)
-#define DTREE_S_FLAG_NOTRIM     (1 << 4)
-#define DTREE_S_MAX_CHAIN       10
-#define DTREE_S_BE_POS          255
-#define DTREE_S_MAX_POS         254
-#define DTREE_S_MAX_RANK        255
-#define DTREE_S_MIN_DIR         -127
-#define DTREE_S_MAX_DIR         127
+#define DTREE_HASH_TCHARS ""
+#define DTREE_HASH_SEP (36 + sizeof(DTREE_HASH_TCHARS) - 1)
+#define DTREE_HASH_SCHARS " -_/\\()."
+#define DTREE_HASH_NCOUNT (DTREE_HASH_SEP + sizeof(DTREE_HASH_SCHARS))
+#define DTREE_HASH_ANY (DTREE_HASH_NCOUNT - 1)
+#define DTREE_PATTERN_ANY '.'
+#define DTREE_PATTERN_OPTIONAL '?'
+#define DTREE_PATTERN_BEGIN '^'
+#define DTREE_PATTERN_END '$'
+#define DTREE_PATTERN_SET_S '['
+#define DTREE_PATTERN_SET_E ']'
+#define DTREE_PATTERN_GROUP_S '('
+#define DTREE_PATTERN_GROUP_E ')'
+#define DTREE_PATTERN_ESCAPE '\\'
+#define DTREE_PATTERN_DQUOTE '\"'
 
-#define DTREE_M_MAX_SLABS       512
-#define DTREE_M_SLAB_SIZE       (1024*512)
-#define DTREE_M_SERROR          "serror"
-#define DTREE_M_LOOKUP_CACHE    6
-#define DTREE_DATA_BUFLEN       128
-#define DTREE_DATA_MKEYS        30
-#define DTREE_DC_DISTANCE(H,S)  ((int)((S)-((char*)(H)->dc_slabs[0])))
+// type defs
+typedef unsigned char dtree_flag_f;
+typedef unsigned char dtree_pos_f;
+typedef unsigned char dtree_rank_f;
+typedef char dtree_dir_f;
 
-#define DTREE_HASH_TCHARS       ""
-#define DTREE_HASH_SEP          (36+sizeof(DTREE_HASH_TCHARS)-1)
-#define DTREE_HASH_SCHARS       " -_/\\()."
-#define DTREE_HASH_NCOUNT       (DTREE_HASH_SEP+sizeof(DTREE_HASH_SCHARS))
-#define DTREE_HASH_ANY          (DTREE_HASH_NCOUNT-1)
-#define DTREE_PATTERN_ANY       '.'
-#define DTREE_PATTERN_OPTIONAL  '?'
-#define DTREE_PATTERN_BEGIN     '^'
-#define DTREE_PATTERN_END       '$'
-#define DTREE_PATTERN_SET_S     '['
-#define DTREE_PATTERN_SET_E     ']'
-#define DTREE_PATTERN_GROUP_S   '('
-#define DTREE_PATTERN_GROUP_E   ')'
-#define DTREE_PATTERN_ESCAPE    '\\'
-#define DTREE_PATTERN_DQUOTE    '\"'
+// dtree dtnode
+typedef struct {
+  char data;
+  dtree_flag_f flags;
 
-
-//type defs
-typedef unsigned char     dtree_flag_f;
-typedef unsigned char     dtree_pos_f;
-typedef unsigned char     dtree_rank_f;
-typedef char              dtree_dir_f;
-
-
-//dtree dtnode
-typedef struct
-{
-    char                  data;
-    dtree_flag_f          flags;
-
-    dtree_pos_f           pos;
-    dtree_rank_f          rank;
-    dtree_dir_f           dir;
+  dtree_pos_f pos;
+  dtree_rank_f rank;
+  dtree_dir_f dir;
 
 #if DTREE_DT_PACKED
-    packed_ptr            nodes[DTREE_HASH_NCOUNT];
-    packed_ptr            curr;
-    packed_ptr            prev;
-    packed_ptr            dup;
+  packed_ptr nodes[DTREE_HASH_NCOUNT];
+  packed_ptr curr;
+  packed_ptr prev;
+  packed_ptr dup;
 #else
-    struct dtree_dt_node  *nodes[DTREE_HASH_NCOUNT];
-    struct dtree_dt_node  *curr;
-    struct dtree_dt_node  *prev;
-    struct dtree_dt_node  *dup;
+  struct dtree_dt_node *nodes[DTREE_HASH_NCOUNT];
+  struct dtree_dt_node *curr;
+  struct dtree_dt_node *prev;
+  struct dtree_dt_node *dup;
 #endif
-    
-    void*                 payload;
-    void*                 cparam;
-}
-dtree_dt_node;
+
+  void *payload;
+  void *cparam;
+} dtree_dt_node;
 
 #if !DTREE_DT_PACKED
-typedef struct dtree_dt_node* packed_ptr;
+typedef struct dtree_dt_node *packed_ptr;
 #endif
 
+// master dtree node
+typedef struct {
+  dtree_flag_f sflags;
 
-//master dtree node
-typedef struct
-{
-    dtree_flag_f          sflags;
-    
-    size_t                node_count;
-    size_t                size;
-    
-    size_t                slab_count;
-    size_t                slab_pos;
-    
-    size_t                dc_slab_count;
-    size_t                dc_slab_pos;
-    size_t                dc_count;
-    
-    dtree_dt_node         *head;
-    
-    char                  *comment;
-    
-    dtree_dt_node         *slabs[DTREE_DT_MAX_SLABS];
-    char                  *dc_slabs[DTREE_M_MAX_SLABS];
-    char                  *dc_cache[DTREE_M_LOOKUP_CACHE];
-}
-dtree_dt_index;
+  size_t node_count;
+  size_t size;
 
+  size_t slab_count;
+  size_t slab_pos;
 
-//add_entry struct
-typedef struct
-{
-    void                  *data;
-    void                  *param;
+  size_t dc_slab_count;
+  size_t dc_slab_pos;
+  size_t dc_count;
 
-    dtree_flag_f          flags;
+  dtree_dt_node *head;
 
-    dtree_pos_f           pos;
-    dtree_rank_f          rank;
-    dtree_dir_f           dir;
-}
-dtree_dt_add_entry;
+  char *comment;
 
+  dtree_dt_node *slabs[DTREE_DT_MAX_SLABS];
+  char *dc_slabs[DTREE_M_MAX_SLABS];
+  char *dc_cache[DTREE_M_LOOKUP_CACHE];
+} dtree_dt_index;
 
-void dtree_init_index(dtree_dt_index*);
+// add_entry struct
+typedef struct {
+  void *data;
+  void *param;
 
-int dtree_add_entry(dtree_dt_index *,const char*,dtree_dt_add_entry*);
+  dtree_flag_f flags;
 
-void *dtree_get(const dtree_dt_index*,const char*,dtree_flag_f);
-const dtree_dt_node *dtree_get_node(const dtree_dt_index*,const char*,dtree_flag_f,dtree_pos_f);
-const dtree_dt_node *dtree_get_flag(const dtree_dt_index*,const dtree_dt_node*,dtree_flag_f,dtree_pos_f);
-dtree_flag_f dtree_get_flags(const dtree_dt_index*,const dtree_dt_node*,dtree_pos_f);
+  dtree_pos_f pos;
+  dtree_rank_f rank;
+  dtree_dir_f dir;
+} dtree_dt_add_entry;
 
-char *dtree_alloc_string(dtree_dt_index*,const char*,int);
-void *dtree_alloc_mem(dtree_dt_index*,size_t);
+void dtree_init_index(dtree_dt_index *);
 
-void dtree_free(dtree_dt_index*);
+int dtree_add_entry(dtree_dt_index *, const char *, dtree_dt_add_entry *);
 
-long dtree_print(const dtree_dt_index*,const char*(*f)(void*));
-void dtree_printd(int,const char*,...);
+void *dtree_get(const dtree_dt_index *, const char *, dtree_flag_f);
+const dtree_dt_node *dtree_get_node(const dtree_dt_index *, const char *,
+                                    dtree_flag_f, dtree_pos_f);
+const dtree_dt_node *dtree_get_flag(const dtree_dt_index *,
+                                    const dtree_dt_node *, dtree_flag_f,
+                                    dtree_pos_f);
+dtree_flag_f dtree_get_flags(const dtree_dt_index *, const dtree_dt_node *,
+                             dtree_pos_f);
 
+char *dtree_alloc_string(dtree_dt_index *, const char *, int);
+void *dtree_alloc_mem(dtree_dt_index *, size_t);
+
+void dtree_free(dtree_dt_index *);
+
+long dtree_print(const dtree_dt_index *, const char *(*f)(void *));
+void dtree_printd(int, const char *, ...);
 
 #ifdef _DTREE_NO_TIMESPEC
-struct timespec
-{
-    long tv_sec;
-    long tv_nsec;
-}
-timespec_t;
+struct timespec {
+  long tv_sec;
+  long tv_nsec;
+} timespec_t;
 #endif
-
 
 #endif /* _DTREE_H_INCLUDED_ */

--- a/src/dtree_core.c
+++ b/src/dtree_core.c
@@ -13,484 +13,478 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
-
 
 #include "dtree_client.h"
 
-
-static int dtree_add_node(dtree_dt_index*,dtree_dt_node*,char*,const dtree_dt_add_entry*);
-static int dtree_set_payload(dtree_dt_index*,dtree_dt_node*,const dtree_dt_add_entry*);
-static const dtree_dt_node *dtree_search_node(const dtree_dt_index*,const dtree_dt_node*,const char*,unsigned char);
+static int dtree_add_node(dtree_dt_index *, dtree_dt_node *, char *,
+                          const dtree_dt_add_entry *);
+static int dtree_set_payload(dtree_dt_index *, dtree_dt_node *,
+                             const dtree_dt_add_entry *);
+static const dtree_dt_node *dtree_search_node(const dtree_dt_index *,
+                                              const dtree_dt_node *,
+                                              const char *, unsigned char);
 unsigned int dtree_hash_char(char);
 
-extern packed_ptr dtree_alloc_node(dtree_dt_index*);
-extern int dtree_node_depth(const dtree_dt_index*,const dtree_dt_node*);
+extern packed_ptr dtree_alloc_node(dtree_dt_index *);
+extern int dtree_node_depth(const dtree_dt_index *, const dtree_dt_node *);
 
+// adds an entry to the tree
+int dtree_add_entry(dtree_dt_index *h, const char *key,
+                    dtree_dt_add_entry *entry) {
+  char namebuf[DTREE_DATA_BUFLEN + 1];
+  packed_ptr pp;
 
-//adds an entry to the tree
-int dtree_add_entry(dtree_dt_index *h,const char *key,dtree_dt_add_entry *entry)
-{
-    char namebuf[DTREE_DATA_BUFLEN+1];
-    packed_ptr pp;
-    
-    if(!key)
-        return 0;
-
-    *namebuf='\0';
-    namebuf[sizeof(namebuf)-1]='\0';
-    
-    strncpy(namebuf+1,key,sizeof(namebuf)-1);
-    
-    if(namebuf[sizeof(namebuf)-1])
-        return 0;
-    
-    dtree_printd(DTREE_PRINT_INITDTREE,"ADD ENTRY: name '%s':%d\n",namebuf+1,entry->flags);
-    
-    if(!h->head)
-    {
-        pp=dtree_alloc_node(h);
-        
-        if(!pp)
-        {
-            fprintf(stderr,"DTREE: allocation error detected, aborting: %zu\n",h->node_count);
-            return -1;
-        }
-        
-        h->head=DTREE_DT_GETPP(h,pp);
-        h->head->curr=pp;
-        h->head->data=0;
-    }
-    
-    if(!entry->flags)
-        entry->flags=DTREE_DT_FLAG_STRONG;
-    
-    return dtree_add_node(h,h->head,namebuf+1,entry);
-}
-
-//adds a node to the tree
-static int dtree_add_node(dtree_dt_index *h,dtree_dt_node *n,char *t,const dtree_dt_add_entry *entry)
-{
-    int hash;
-    char *s;
-    packed_ptr pp;
-    dtree_dt_node *next;
-    
-    if(!n)
-        return 0;
-    
-    dtree_printd(DTREE_PRINT_INITDTREE,"ADD: tree: '%c' level: %d t: '%s' p(%p) pp(%p)\n",
-             n->data?n->data:'^',dtree_node_depth(h,n),t,n,n->curr);
-    
-    //escape
-    if(h->sflags & DTREE_S_FLAG_REGEX && (*t==DTREE_PATTERN_ESCAPE) && *(t-1)!=DTREE_PATTERN_ESCAPE)
-        t++;
-
-    //(abc)
-    while(h->sflags & DTREE_S_FLAG_REGEX && (*t==DTREE_PATTERN_GROUP_S || *t==DTREE_PATTERN_GROUP_E) &&
-            *(t-1)!=DTREE_PATTERN_ESCAPE)
-    {
-        hash=(*t==DTREE_PATTERN_GROUP_S);
-        s=t+1;
-
-        while(*s && hash)
-        {
-            if(*s==DTREE_PATTERN_GROUP_S && *(s-1)!=DTREE_PATTERN_ESCAPE)
-                hash++;
-            else if(*s==DTREE_PATTERN_GROUP_E && *(s-1)!=DTREE_PATTERN_ESCAPE)
-                hash--;
-
-            s++;
-        }
-
-        if(*t==DTREE_PATTERN_GROUP_S)
-        {
-            dtree_printd(DTREE_PRINT_INITDTREE,"ADD: group detected: '%c' - '%c'\n",*(t+1)?*(t+1):'#',*s?*s:'#');
-
-            //optional group
-            if(*s==DTREE_PATTERN_OPTIONAL && *(s-1)!=DTREE_PATTERN_ESCAPE)
-            {
-                if(dtree_add_node(h,n,s+1,entry)<0)
-                    return -1;
-            }
-        }
-
-        t++;
-    }
-
-    //?
-    if(h->sflags & DTREE_S_FLAG_REGEX && *t==DTREE_PATTERN_OPTIONAL && *(t-1)!=DTREE_PATTERN_ESCAPE)
-    {
-        //no group
-        if(*(t-1)!=DTREE_PATTERN_GROUP_E || *(t-2)==DTREE_PATTERN_ESCAPE)
-        {
-            pp=n->prev;
-            next=DTREE_DT_GETPP(h,pp);
-        
-            if(!pp)
-                return 0;
-        
-            dtree_printd(DTREE_PRINT_INITDTREE,"ADD: optional: '%c' t: '%s'\n",next->data?next->data:'^',(t+1));
-        
-            if(dtree_add_node(h,next,t+1,entry)<0)
-                return -1;
-        }
-
-        t++;
-
-        return dtree_add_node(h,n,t,entry);
-    }
-
-    //EOT
-    if(!*t && n->prev)
-        return dtree_set_payload(h,n,entry);
-    
-    //[abc]
-    if(h->sflags & DTREE_S_FLAG_REGEX && *t==DTREE_PATTERN_SET_S && *(t-1)!=DTREE_PATTERN_ESCAPE)
-    {
-        for(s=t;*s;s++)
-        {
-            if(*s==DTREE_PATTERN_SET_E && *(s-1)!=DTREE_PATTERN_ESCAPE)
-                break;
-        }
-        
-        if(!*s)
-            return 0;
-        
-        t++;
-        
-        while(t<s)
-        {
-            *s=*t;
-            
-            dtree_printd(DTREE_PRINT_INITDTREE,"ADD: set: '%c' *t: '%c' t: '%s'\n",n->data?n->data:'^',*t,s);
-            
-            if(dtree_add_node(h,n,s,entry)<0)
-                return -1;
-            
-            t++;
-        }
-        
-        *s=DTREE_PATTERN_SET_E;
-        
-        return 1;
-    }
-    
-    hash=dtree_hash_char(*t);
-        
-    if(!hash && *t!='0')
-        return 0;
-        
-    if(*t>='A' && *t<='Z')
-        *t|=0x20;
-        
-    //.
-    if(h->sflags & DTREE_S_FLAG_REGEX && *t==DTREE_PATTERN_ANY && *(t-1)!=DTREE_PATTERN_ESCAPE)
-        hash=DTREE_HASH_ANY;
-        
-    pp=(packed_ptr)n->nodes[hash];
-    next=DTREE_DT_GETPP(h,pp);
-        
-    if(!pp)
-    {
-        pp=dtree_alloc_node(h);
-        next=DTREE_DT_GETPP(h,pp);
-        
-        if(!pp)
-        {
-            fprintf(stderr,"DTREE: allocation error detected, aborting: %zu\n",h->node_count);
-            return -1;
-        }
-        
-        if(hash==DTREE_HASH_ANY)
-            next->data=DTREE_PATTERN_ANY;
-        else
-            next->data=*t;
-
-        next->curr=pp;
-        next->prev=n->curr;
-        
-        n->nodes[hash]=pp;
-        
-        dtree_printd(DTREE_PRINT_INITDTREE,"ADD: new node '%c' created level: %d hash: %d p(%p) pp(%p)\n",
-                 *t,dtree_node_depth(h,n),hash,next,pp);
-    }
-    
-    //EOT
-    if(!*(t+1))
-        return dtree_set_payload(h,next,entry);
-
-    return dtree_add_node(h,next,t+1,entry);
-}
-
-//sets the data, param, and type for a node
-static int dtree_set_payload(dtree_dt_index *h,dtree_dt_node *n,const dtree_dt_add_entry *entry)
-{
-    packed_ptr pp;
-    dtree_dt_node *base=n;
-    
-    if((entry->flags & n->flags)==entry->flags && entry->data==n->payload && entry->param==n->cparam &&
-            entry->pos==n->pos && entry->dir==n->dir)
-    {
-        dtree_printd(DTREE_PRINT_INITDTREE,"ADD: PURE DUPLICATE detected, skipping\n");
-    
-        return 0;
-    }
-    
-    dtree_printd(DTREE_PRINT_INITDTREE,"ADD: EOT: '%c' level: %d p(%p) pp(%p) param(%p) flags: %d\n",
-             n->data?n->data:'^',dtree_node_depth(h,n),n,n->curr,entry->param,entry->flags);
-    
-    if(n->flags && (h->sflags & DTREE_S_FLAG_DUPS))
-    {
-        dtree_printd(DTREE_PRINT_INITDTREE,"ADD: DUPLICATE detected, adding\n");
-        
-        pp=n->dup;
-        
-        //iterate thru the dups
-        while(pp)
-        {
-            n=DTREE_DT_GETPP(h,pp);
-            
-            //dup
-            if((entry->flags & n->flags)==entry->flags && entry->data==n->payload && entry->param==n->cparam &&
-                    entry->pos==n->pos && entry->dir==n->dir)
-                return 0;
-            
-            pp=n->dup;
-        }
-        
-        pp=dtree_alloc_node(h);
-        
-        if(!pp)
-        {
-            fprintf(stderr,"DTREE: allocation error detected, aborting: %zu\n",h->node_count);
-            return -1;
-        }
-        
-        n->dup=pp;
-        
-        n=DTREE_DT_GETPP(h,pp);
-        
-        n->curr=base->curr;
-        n->prev=base->prev;
-        n->data=base->data;
-        
-        return dtree_set_payload(h,n,entry);
-    }
-    else if(n->flags && !(h->sflags & DTREE_S_FLAG_DUPS))
-        dtree_printd(DTREE_PRINT_INITDTREE,"ADD: DUPLICATE detected, overwriting original\n");
-    
-    n->flags=DTREE_DT_FLAG_TOKEN;
-    n->flags|=entry->flags;
-
-    n->payload=entry->data;
-    n->cparam=entry->param;
-
-    n->pos=entry->pos;
-    n->rank=entry->rank;
-    n->dir=entry->dir;
-    
-    return 1;
-}
-
-//hashes a character, on error 0 is returned
-unsigned int dtree_hash_char(char c)
-{
-    unsigned int i,m;
-    
-    //alphanumeric
-    if(c<='z' && c>='a')
-        return c-'a'+10;
-    else if(c>='A' && c<='Z')
-        return c-'A'+10;
-    else if(c<='9' && c>='0')
-        return c-'0';
-    
-    //configurable
-    m=sizeof(DTREE_HASH_TCHARS)-1;
-    for(i=0;i<m;i++)
-    {
-        if(c==DTREE_HASH_TCHARS[i])
-            return 36+i;
-    }
-    
-    //configurable
-    m=sizeof(DTREE_HASH_SCHARS)-1;
-    for(i=0;i<m;i++)
-    {
-        if(c==DTREE_HASH_SCHARS[i])
-            return DTREE_HASH_SEP+i;
-    }
-    
-    //wildcard
-    if(c>=' ' && c<='~')
-        return DTREE_HASH_ANY;
-    
-    //unsupported
+  if (!key)
     return 0;
+
+  *namebuf = '\0';
+  namebuf[sizeof(namebuf) - 1] = '\0';
+
+  strncpy(namebuf + 1, key, sizeof(namebuf) - 1);
+
+  if (namebuf[sizeof(namebuf) - 1])
+    return 0;
+
+  dtree_printd(DTREE_PRINT_INITDTREE, "ADD ENTRY: name '%s':%d\n", namebuf + 1,
+               entry->flags);
+
+  if (!h->head) {
+    pp = dtree_alloc_node(h);
+
+    if (!pp) {
+      fprintf(stderr, "DTREE: allocation error detected, aborting: %zu\n",
+              h->node_count);
+      return -1;
+    }
+
+    h->head = DTREE_DT_GETPP(h, pp);
+    h->head->curr = pp;
+    h->head->data = 0;
+  }
+
+  if (!entry->flags)
+    entry->flags = DTREE_DT_FLAG_STRONG;
+
+  return dtree_add_node(h, h->head, namebuf + 1, entry);
 }
 
-//dtree lookup
-void *dtree_get(const dtree_dt_index *h,const char *str,dtree_flag_f filter)
-{
-    const dtree_dt_node *ret;
-    const dtree_dt_node *fnode;
-    
-    if(!str || !h->head)
-        return NULL;
-    
-    ret=dtree_get_node(h,str,DTREE_S_FLAG_NONE,0);
-    
-    if(ret)
-    {
-        if(filter)
-        {
-            fnode=dtree_get_flag(h,ret,filter,0);
-            
-            if(fnode)
-                return fnode->payload;
-        }
-        else
-            return ret->payload;
+// adds a node to the tree
+static int dtree_add_node(dtree_dt_index *h, dtree_dt_node *n, char *t,
+                          const dtree_dt_add_entry *entry) {
+  int hash;
+  char *s;
+  packed_ptr pp;
+  dtree_dt_node *next;
+
+  if (!n)
+    return 0;
+
+  dtree_printd(DTREE_PRINT_INITDTREE,
+               "ADD: tree: '%c' level: %d t: '%s' p(%p) pp(%p)\n",
+               n->data ? n->data : '^', dtree_node_depth(h, n), t, n, n->curr);
+
+  // escape
+  if (h->sflags & DTREE_S_FLAG_REGEX && (*t == DTREE_PATTERN_ESCAPE) &&
+      *(t - 1) != DTREE_PATTERN_ESCAPE)
+    t++;
+
+  //(abc)
+  while (h->sflags & DTREE_S_FLAG_REGEX &&
+         (*t == DTREE_PATTERN_GROUP_S || *t == DTREE_PATTERN_GROUP_E) &&
+         *(t - 1) != DTREE_PATTERN_ESCAPE) {
+    hash = (*t == DTREE_PATTERN_GROUP_S);
+    s = t + 1;
+
+    while (*s && hash) {
+      if (*s == DTREE_PATTERN_GROUP_S && *(s - 1) != DTREE_PATTERN_ESCAPE)
+        hash++;
+      else if (*s == DTREE_PATTERN_GROUP_E && *(s - 1) != DTREE_PATTERN_ESCAPE)
+        hash--;
+
+      s++;
     }
-    
+
+    if (*t == DTREE_PATTERN_GROUP_S) {
+      dtree_printd(DTREE_PRINT_INITDTREE, "ADD: group detected: '%c' - '%c'\n",
+                   *(t + 1) ? *(t + 1) : '#', *s ? *s : '#');
+
+      // optional group
+      if (*s == DTREE_PATTERN_OPTIONAL && *(s - 1) != DTREE_PATTERN_ESCAPE) {
+        if (dtree_add_node(h, n, s + 1, entry) < 0)
+          return -1;
+      }
+    }
+
+    t++;
+  }
+
+  //?
+  if (h->sflags & DTREE_S_FLAG_REGEX && *t == DTREE_PATTERN_OPTIONAL &&
+      *(t - 1) != DTREE_PATTERN_ESCAPE) {
+    // no group
+    if (*(t - 1) != DTREE_PATTERN_GROUP_E || *(t - 2) == DTREE_PATTERN_ESCAPE) {
+      pp = n->prev;
+      next = DTREE_DT_GETPP(h, pp);
+
+      if (!pp)
+        return 0;
+
+      dtree_printd(DTREE_PRINT_INITDTREE, "ADD: optional: '%c' t: '%s'\n",
+                   next->data ? next->data : '^', (t + 1));
+
+      if (dtree_add_node(h, next, t + 1, entry) < 0)
+        return -1;
+    }
+
+    t++;
+
+    return dtree_add_node(h, n, t, entry);
+  }
+
+  // EOT
+  if (!*t && n->prev)
+    return dtree_set_payload(h, n, entry);
+
+  //[abc]
+  if (h->sflags & DTREE_S_FLAG_REGEX && *t == DTREE_PATTERN_SET_S &&
+      *(t - 1) != DTREE_PATTERN_ESCAPE) {
+    for (s = t; *s; s++) {
+      if (*s == DTREE_PATTERN_SET_E && *(s - 1) != DTREE_PATTERN_ESCAPE)
+        break;
+    }
+
+    if (!*s)
+      return 0;
+
+    t++;
+
+    while (t < s) {
+      *s = *t;
+
+      dtree_printd(DTREE_PRINT_INITDTREE, "ADD: set: '%c' *t: '%c' t: '%s'\n",
+                   n->data ? n->data : '^', *t, s);
+
+      if (dtree_add_node(h, n, s, entry) < 0)
+        return -1;
+
+      t++;
+    }
+
+    *s = DTREE_PATTERN_SET_E;
+
+    return 1;
+  }
+
+  hash = dtree_hash_char(*t);
+
+  if (!hash && *t != '0')
+    return 0;
+
+  if (*t >= 'A' && *t <= 'Z')
+    *t |= 0x20;
+
+  //.
+  if (h->sflags & DTREE_S_FLAG_REGEX && *t == DTREE_PATTERN_ANY &&
+      *(t - 1) != DTREE_PATTERN_ESCAPE)
+    hash = DTREE_HASH_ANY;
+
+  pp = (packed_ptr)n->nodes[hash];
+  next = DTREE_DT_GETPP(h, pp);
+
+  if (!pp) {
+    pp = dtree_alloc_node(h);
+    next = DTREE_DT_GETPP(h, pp);
+
+    if (!pp) {
+      fprintf(stderr, "DTREE: allocation error detected, aborting: %zu\n",
+              h->node_count);
+      return -1;
+    }
+
+    if (hash == DTREE_HASH_ANY)
+      next->data = DTREE_PATTERN_ANY;
+    else
+      next->data = *t;
+
+    next->curr = pp;
+    next->prev = n->curr;
+
+    n->nodes[hash] = pp;
+
+    dtree_printd(DTREE_PRINT_INITDTREE,
+                 "ADD: new node '%c' created level: %d hash: %d p(%p) pp(%p)\n",
+                 *t, dtree_node_depth(h, n), hash, next, pp);
+  }
+
+  // EOT
+  if (!*(t + 1))
+    return dtree_set_payload(h, next, entry);
+
+  return dtree_add_node(h, next, t + 1, entry);
+}
+
+// sets the data, param, and type for a node
+static int dtree_set_payload(dtree_dt_index *h, dtree_dt_node *n,
+                             const dtree_dt_add_entry *entry) {
+  packed_ptr pp;
+  dtree_dt_node *base = n;
+
+  if ((entry->flags & n->flags) == entry->flags && entry->data == n->payload &&
+      entry->param == n->cparam && entry->pos == n->pos &&
+      entry->dir == n->dir) {
+    dtree_printd(DTREE_PRINT_INITDTREE,
+                 "ADD: PURE DUPLICATE detected, skipping\n");
+
+    return 0;
+  }
+
+  dtree_printd(DTREE_PRINT_INITDTREE,
+               "ADD: EOT: '%c' level: %d p(%p) pp(%p) param(%p) flags: %d\n",
+               n->data ? n->data : '^', dtree_node_depth(h, n), n, n->curr,
+               entry->param, entry->flags);
+
+  if (n->flags && (h->sflags & DTREE_S_FLAG_DUPS)) {
+    dtree_printd(DTREE_PRINT_INITDTREE, "ADD: DUPLICATE detected, adding\n");
+
+    pp = n->dup;
+
+    // iterate thru the dups
+    while (pp) {
+      n = DTREE_DT_GETPP(h, pp);
+
+      // dup
+      if ((entry->flags & n->flags) == entry->flags &&
+          entry->data == n->payload && entry->param == n->cparam &&
+          entry->pos == n->pos && entry->dir == n->dir)
+        return 0;
+
+      pp = n->dup;
+    }
+
+    pp = dtree_alloc_node(h);
+
+    if (!pp) {
+      fprintf(stderr, "DTREE: allocation error detected, aborting: %zu\n",
+              h->node_count);
+      return -1;
+    }
+
+    n->dup = pp;
+
+    n = DTREE_DT_GETPP(h, pp);
+
+    n->curr = base->curr;
+    n->prev = base->prev;
+    n->data = base->data;
+
+    return dtree_set_payload(h, n, entry);
+  } else if (n->flags && !(h->sflags & DTREE_S_FLAG_DUPS))
+    dtree_printd(DTREE_PRINT_INITDTREE,
+                 "ADD: DUPLICATE detected, overwriting original\n");
+
+  n->flags = DTREE_DT_FLAG_TOKEN;
+  n->flags |= entry->flags;
+
+  n->payload = entry->data;
+  n->cparam = entry->param;
+
+  n->pos = entry->pos;
+  n->rank = entry->rank;
+  n->dir = entry->dir;
+
+  return 1;
+}
+
+// hashes a character, on error 0 is returned
+unsigned int dtree_hash_char(char c) {
+  unsigned int i, m;
+
+  // alphanumeric
+  if (c <= 'z' && c >= 'a')
+    return c - 'a' + 10;
+  else if (c >= 'A' && c <= 'Z')
+    return c - 'A' + 10;
+  else if (c <= '9' && c >= '0')
+    return c - '0';
+
+  // configurable
+  m = sizeof(DTREE_HASH_TCHARS) - 1;
+  for (i = 0; i < m; i++) {
+    if (c == DTREE_HASH_TCHARS[i])
+      return 36 + i;
+  }
+
+  // configurable
+  m = sizeof(DTREE_HASH_SCHARS) - 1;
+  for (i = 0; i < m; i++) {
+    if (c == DTREE_HASH_SCHARS[i])
+      return DTREE_HASH_SEP + i;
+  }
+
+  // wildcard
+  if (c >= ' ' && c <= '~')
+    return DTREE_HASH_ANY;
+
+  // unsupported
+  return 0;
+}
+
+// dtree lookup
+void *dtree_get(const dtree_dt_index *h, const char *str, dtree_flag_f filter) {
+  const dtree_dt_node *ret;
+  const dtree_dt_node *fnode;
+
+  if (!str || !h->head)
     return NULL;
+
+  ret = dtree_get_node(h, str, DTREE_S_FLAG_NONE, 0);
+
+  if (ret) {
+    if (filter) {
+      fnode = dtree_get_flag(h, ret, filter, 0);
+
+      if (fnode)
+        return fnode->payload;
+    } else
+      return ret->payload;
+  }
+
+  return NULL;
 }
 
-//gets the flag for a token
-const dtree_dt_node *dtree_get_node(const dtree_dt_index *h,const char *t,dtree_flag_f sflags,dtree_pos_f pos)
-{
-    unsigned int hash;
-    char n;
-    const char *p;
-    packed_ptr pp;
-    const dtree_dt_node *base;
-    const dtree_dt_node *lflag=NULL;
-    
-    if(!sflags)
-        sflags=h->sflags;
-    
-    if(sflags & DTREE_S_FLAG_REGEX)
-    {
-        pp=h->head->nodes[dtree_hash_char(*t)];
-        base=DTREE_DT_GETPP(h,pp);
-        
-        lflag=dtree_search_node(h,base,t,pos);
-        
-        //leading wildcard
-        if(!lflag)
-        {
-            pp=h->head->nodes[DTREE_HASH_ANY];
-            base=DTREE_DT_GETPP(h,pp);
-            
-            if(pp)
-                lflag=dtree_search_node(h,base,t,pos);
-        }
-        
-        return lflag;
-    }
-    
-    pp=h->head->nodes[dtree_hash_char(*t)];
-    base=DTREE_DT_GETPP(h,pp);
-    
-    //iterative search
-    for(p=t;*p && pp;p++)
-    {
-        if(base->data!=*p && base->data!=(*p|0x20) && base->data!=DTREE_PATTERN_ANY)
-            break;
-   
-        n=*(p+1);
-        hash=dtree_hash_char(n);
-        
-        //token match
-        if((!hash && n!='0') || hash>=DTREE_HASH_SEP)
-        {
-            //match is valid with position
-            if(base->flags && (sflags & DTREE_S_FLAG_PARTIAL || !n) &&
-                    (!base->pos || !pos || base->pos==pos))
-                return base;
-            else if(!n)
-                break;
-        }
-        
-        pp=base->nodes[hash];
-        base=DTREE_DT_GETPP(h,pp);
+// gets the flag for a token
+const dtree_dt_node *dtree_get_node(const dtree_dt_index *h, const char *t,
+                                    dtree_flag_f sflags, dtree_pos_f pos) {
+  unsigned int hash;
+  char n;
+  const char *p;
+  packed_ptr pp;
+  const dtree_dt_node *base;
+  const dtree_dt_node *lflag = NULL;
+
+  if (!sflags)
+    sflags = h->sflags;
+
+  if (sflags & DTREE_S_FLAG_REGEX) {
+    pp = h->head->nodes[dtree_hash_char(*t)];
+    base = DTREE_DT_GETPP(h, pp);
+
+    lflag = dtree_search_node(h, base, t, pos);
+
+    // leading wildcard
+    if (!lflag) {
+      pp = h->head->nodes[DTREE_HASH_ANY];
+      base = DTREE_DT_GETPP(h, pp);
+
+      if (pp)
+        lflag = dtree_search_node(h, base, t, pos);
     }
 
     return lflag;
+  }
+
+  pp = h->head->nodes[dtree_hash_char(*t)];
+  base = DTREE_DT_GETPP(h, pp);
+
+  // iterative search
+  for (p = t; *p && pp; p++) {
+    if (base->data != *p && base->data != (*p | 0x20) &&
+        base->data != DTREE_PATTERN_ANY)
+      break;
+
+    n = *(p + 1);
+    hash = dtree_hash_char(n);
+
+    // token match
+    if ((!hash && n != '0') || hash >= DTREE_HASH_SEP) {
+      // match is valid with position
+      if (base->flags && (sflags & DTREE_S_FLAG_PARTIAL || !n) &&
+          (!base->pos || !pos || base->pos == pos))
+        return base;
+      else if (!n)
+        break;
+    }
+
+    pp = base->nodes[hash];
+    base = DTREE_DT_GETPP(h, pp);
+  }
+
+  return lflag;
 }
 
-//searches for a token with regex
-static const dtree_dt_node *dtree_search_node(const dtree_dt_index *h,const dtree_dt_node *n,const char *t,dtree_pos_f pos)
-{
-    unsigned int hash;
-    dtree_flag_f rf,nf;
-    packed_ptr pp;
-    const dtree_dt_node *rflag;
-    
-    if(!n || !n->curr)
-        return NULL;
-    
-    //bad match
-    if(n->data!=*t && n->data!=(*t|0x20) && n->data!=DTREE_PATTERN_ANY)
-        return NULL;
-    
-    t++;
-    hash=dtree_hash_char(*t);
-    
-    //EOS
-    if(!hash && *t!='0')
-    {
-        //only quit if strong with position
-        if(dtree_get_flag(h,n,DTREE_DT_FLAG_STRONG,pos))
-            return n;
-        else if(!n->flags)
-            return NULL;
-    }
-    
-    pp=n->nodes[hash];
-    rflag=DTREE_DT_GETPP(h,pp);
-    
-    if(pp)
-        rflag=dtree_search_node(h,rflag,t,pos);
+// searches for a token with regex
+static const dtree_dt_node *dtree_search_node(const dtree_dt_index *h,
+                                              const dtree_dt_node *n,
+                                              const char *t, dtree_pos_f pos) {
+  unsigned int hash;
+  dtree_flag_f rf, nf;
+  packed_ptr pp;
+  const dtree_dt_node *rflag;
+
+  if (!n || !n->curr)
+    return NULL;
+
+  // bad match
+  if (n->data != *t && n->data != (*t | 0x20) && n->data != DTREE_PATTERN_ANY)
+    return NULL;
+
+  t++;
+  hash = dtree_hash_char(*t);
+
+  // EOS
+  if (!hash && *t != '0') {
+    // only quit if strong with position
+    if (dtree_get_flag(h, n, DTREE_DT_FLAG_STRONG, pos))
+      return n;
+    else if (!n->flags)
+      return NULL;
+  }
+
+  pp = n->nodes[hash];
+  rflag = DTREE_DT_GETPP(h, pp);
+
+  if (pp)
+    rflag = dtree_search_node(h, rflag, t, pos);
+  else
+    rflag = NULL;
+
+  // wildcard
+  if (!rflag) {
+    hash = DTREE_HASH_ANY;
+
+    pp = n->nodes[hash];
+    rflag = DTREE_DT_GETPP(h, pp);
+
+    if (pp)
+      rflag = dtree_search_node(h, rflag, t, pos);
     else
-        rflag=NULL;
-    
-    //wildcard
-    if(!rflag)
-    {
-        hash=DTREE_HASH_ANY;
-        
-        pp=n->nodes[hash];
-        rflag=DTREE_DT_GETPP(h,pp);
-        
-        if(pp)
-            rflag=dtree_search_node(h,rflag,t,pos);
-        else
-            rflag=NULL;
-        
-        hash=dtree_hash_char(*t);
-    }
-    
-    //n is lazy EOT or stronger match
-    if((n->flags & DTREE_DT_FLAG_TOKEN) && ((!hash && *t!='0') || hash>=DTREE_HASH_SEP))
-    {
-        nf=dtree_get_flags(h,n,pos);
-        rf=dtree_get_flags(h,rflag,pos);
-        
-        if(!rflag)
-            rflag=n;
-        else if((nf & DTREE_DT_FLAG_STRONG) && !(rf & DTREE_DT_FLAG_STRONG))
-            rflag=n;
-        else if(rf & DTREE_DT_FLAG_STRONG);
-        else if((nf & DTREE_DT_FLAG_CHAIN) && !(nf & DTREE_DT_FLAG_BCHAIN) &&
-                !(rf & DTREE_DT_FLAG_CHAIN) && !(rf & DTREE_DT_FLAG_BCHAIN))
-            rflag=n;
-        else if(rf & DTREE_DT_FLAG_CHAIN);
-        else if((nf & DTREE_DT_FLAG_WEAK) && !(rf & DTREE_DT_FLAG_WEAK))
-            rflag=n;
-    }
-    
-    return rflag;
+      rflag = NULL;
+
+    hash = dtree_hash_char(*t);
+  }
+
+  // n is lazy EOT or stronger match
+  if ((n->flags & DTREE_DT_FLAG_TOKEN) &&
+      ((!hash && *t != '0') || hash >= DTREE_HASH_SEP)) {
+    nf = dtree_get_flags(h, n, pos);
+    rf = dtree_get_flags(h, rflag, pos);
+
+    if (!rflag)
+      rflag = n;
+    else if ((nf & DTREE_DT_FLAG_STRONG) && !(rf & DTREE_DT_FLAG_STRONG))
+      rflag = n;
+    else if (rf & DTREE_DT_FLAG_STRONG)
+      ;
+    else if ((nf & DTREE_DT_FLAG_CHAIN) && !(nf & DTREE_DT_FLAG_BCHAIN) &&
+             !(rf & DTREE_DT_FLAG_CHAIN) && !(rf & DTREE_DT_FLAG_BCHAIN))
+      rflag = n;
+    else if (rf & DTREE_DT_FLAG_CHAIN)
+      ;
+    else if ((nf & DTREE_DT_FLAG_WEAK) && !(rf & DTREE_DT_FLAG_WEAK))
+      rflag = n;
+  }
+
+  return rflag;
 }

--- a/src/dtree_mem.c
+++ b/src/dtree_mem.c
@@ -13,208 +13,197 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
-
 
 #include "dtree_client.h"
 
+packed_ptr dtree_alloc_node(dtree_dt_index *);
+static void *dtree_alloc_mem_align(dtree_dt_index *, size_t, size_t);
 
-packed_ptr dtree_alloc_node(dtree_dt_index*);
-static void *dtree_alloc_mem_align(dtree_dt_index*,size_t,size_t);
+// allocates a new dtree node
+packed_ptr dtree_alloc_node(dtree_dt_index *h) {
+  packed_ptr pp;
+  dtree_dt_node *p;
 
-
-//allocates a new dtree node
-packed_ptr dtree_alloc_node(dtree_dt_index *h)
-{
-    packed_ptr pp;
-    dtree_dt_node *p;
-
-    if(h->node_count>=(h->slab_count*DTREE_DT_SLAB_SIZE))
-    {
-        if(h->slab_count>=DTREE_DT_MAX_SLABS)
-        {
-            dtree_printd(DTREE_PRINT_INITDTREE,"NALLOC: ERROR: all slabs allocated\n");
-            return (packed_ptr)0;
-        }
-        
-        dtree_printd(DTREE_PRINT_INITDTREE,"NALLOC: allocating new SLAB\n");
-        
-        p=calloc(DTREE_DT_SLAB_SIZE,sizeof(dtree_dt_node));
-        
-        if(!p)
-        {
-            dtree_printd(DTREE_PRINT_INITDTREE,"NMALLOC: ERROR: calloc memory allocation failure: %d\n",DTREE_DT_SLAB_SIZE);
-            return (packed_ptr)0;
-        }
-        
-        h->size+=DTREE_DT_SLAB_SIZE*sizeof(dtree_dt_node);
-        h->slabs[h->slab_count]=p;
-        h->slab_count++;
-        h->slab_pos=0;
+  if (h->node_count >= (h->slab_count * DTREE_DT_SLAB_SIZE)) {
+    if (h->slab_count >= DTREE_DT_MAX_SLABS) {
+      dtree_printd(DTREE_PRINT_INITDTREE,
+                   "NALLOC: ERROR: all slabs allocated\n");
+      return (packed_ptr)0;
     }
-    
-    //return next open node on slab
-    p=h->slabs[h->slab_count-1];
-    
-    if(!p)
-        return (packed_ptr)0;
-    
-    p=&p[h->slab_pos];
-    pp=DTREE_DT_GENPP(p,h->slab_count-1,h->slab_pos);
-    
-    dtree_printd(DTREE_PRINT_INITDTREE,"NALLOC: node %zu off of slab %zu p(%p) pp(%p)\n",
-             h->slab_pos,h->slab_count,p,pp);
-    
-    h->slab_pos++;
-    h->node_count++;
-    
-    //bypass null packed_ptr
-    if(!pp)
-        return dtree_alloc_node(h);
-    
-    return pp;
+
+    dtree_printd(DTREE_PRINT_INITDTREE, "NALLOC: allocating new SLAB\n");
+
+    p = calloc(DTREE_DT_SLAB_SIZE, sizeof(dtree_dt_node));
+
+    if (!p) {
+      dtree_printd(DTREE_PRINT_INITDTREE,
+                   "NMALLOC: ERROR: calloc memory allocation failure: %d\n",
+                   DTREE_DT_SLAB_SIZE);
+      return (packed_ptr)0;
+    }
+
+    h->size += DTREE_DT_SLAB_SIZE * sizeof(dtree_dt_node);
+    h->slabs[h->slab_count] = p;
+    h->slab_count++;
+    h->slab_pos = 0;
+  }
+
+  // return next open node on slab
+  p = h->slabs[h->slab_count - 1];
+
+  if (!p)
+    return (packed_ptr)0;
+
+  p = &p[h->slab_pos];
+  pp = DTREE_DT_GENPP(p, h->slab_count - 1, h->slab_pos);
+
+  dtree_printd(DTREE_PRINT_INITDTREE,
+               "NALLOC: node %zu off of slab %zu p(%p) pp(%p)\n", h->slab_pos,
+               h->slab_count, p, pp);
+
+  h->slab_pos++;
+  h->node_count++;
+
+  // bypass null packed_ptr
+  if (!pp)
+    return dtree_alloc_node(h);
+
+  return pp;
 }
 
-//allocates memory
-void *dtree_alloc_mem(dtree_dt_index *h,size_t len)
-{
-    return dtree_alloc_mem_align(h,len,sizeof(h));
+// allocates memory
+void *dtree_alloc_mem(dtree_dt_index *h, size_t len) {
+  return dtree_alloc_mem_align(h, len, sizeof(h));
 }
 
-//aligned memory allocation
-static void *dtree_alloc_mem_align(dtree_dt_index *h,size_t len,size_t align)
-{
-    char *ret;
-    size_t olen=0;
-    size_t nlen;
-    
-    if(h->dc_slab_pos%align && !(align&(align-1)))
-    {
-        olen=((h->dc_slab_pos+align-1) & (~(align-1))) - h->dc_slab_pos;
-        dtree_printd(DTREE_PRINT_INITDTREE,"DMALLOC: unaligned(%zu) offset detected %zu => %zu\n",
-                 align,h->dc_slab_pos,h->dc_slab_pos+olen);
-    }
-    
-    nlen=len+olen;
-    
-    if(h->dc_slab_count>=DTREE_M_MAX_SLABS)
-    {
-        dtree_printd(DTREE_PRINT_INITDTREE,"DMALLOC: ERROR: out of slabs: %zu\n",h->dc_slab_count);
-        return NULL;
-    }
-    
-    if(!h->dc_slabs[h->dc_slab_count])
-    {
-        //alloc new slab
-        h->dc_slabs[h->dc_slab_count]=calloc(DTREE_M_SLAB_SIZE,sizeof(char));
-        
-        if(!h->dc_slabs[h->dc_slab_count])
-        {
-            dtree_printd(DTREE_PRINT_INITDTREE,"DMALLOC: ERROR: calloc memory allocation failure: %d\n",DTREE_M_SLAB_SIZE);
-            return NULL;
-        }
-        
-        h->dc_slab_pos=0;
-        h->size+=DTREE_M_SLAB_SIZE*sizeof(char);
+// aligned memory allocation
+static void *dtree_alloc_mem_align(dtree_dt_index *h, size_t len,
+                                   size_t align) {
+  char *ret;
+  size_t olen = 0;
+  size_t nlen;
+
+  if (h->dc_slab_pos % align && !(align & (align - 1))) {
+    olen = ((h->dc_slab_pos + align - 1) & (~(align - 1))) - h->dc_slab_pos;
+    dtree_printd(DTREE_PRINT_INITDTREE,
+                 "DMALLOC: unaligned(%zu) offset detected %zu => %zu\n", align,
+                 h->dc_slab_pos, h->dc_slab_pos + olen);
+  }
+
+  nlen = len + olen;
+
+  if (h->dc_slab_count >= DTREE_M_MAX_SLABS) {
+    dtree_printd(DTREE_PRINT_INITDTREE, "DMALLOC: ERROR: out of slabs: %zu\n",
+                 h->dc_slab_count);
+    return NULL;
+  }
+
+  if (!h->dc_slabs[h->dc_slab_count]) {
+    // alloc new slab
+    h->dc_slabs[h->dc_slab_count] = calloc(DTREE_M_SLAB_SIZE, sizeof(char));
+
+    if (!h->dc_slabs[h->dc_slab_count]) {
+      dtree_printd(DTREE_PRINT_INITDTREE,
+                   "DMALLOC: ERROR: calloc memory allocation failure: %d\n",
+                   DTREE_M_SLAB_SIZE);
+      return NULL;
     }
 
-    if(nlen>DTREE_M_SLAB_SIZE || !len)
-    {
-        dtree_printd(DTREE_PRINT_INITDTREE,"DMALLOC: ERROR: size too large: %zu\n",len);
-        return NULL;
-    }
-    
-    if(h->dc_slab_pos+nlen>DTREE_M_SLAB_SIZE)
-    {
-        //move to next slab
-        h->dc_slab_count++;
-        h->dc_slab_pos=0;
-        return dtree_alloc_mem_align(h,len,align);
-    }
-    
-    //alloc memory
-    ret=h->dc_slabs[h->dc_slab_count]+h->dc_slab_pos+olen;
-    
-    if(((size_t)ret%align))
-    {
-        dtree_printd(DTREE_PRINT_INITDTREE,"DMALLOC: ERROR: misalignment\n");
-        return NULL;
-    }
-    
-    h->dc_count++;
-    
-    dtree_printd(DTREE_PRINT_INITDTREE,"DMALLOC: memory: %zu,%zu+%zu,%zu(%p) align: %zu\n",
-             h->dc_slab_count,h->dc_slab_pos,olen,len,ret,align);
-    
-    h->dc_slab_pos=(ret-h->dc_slabs[h->dc_slab_count])+len;
-    
-    return (void*)ret;
+    h->dc_slab_pos = 0;
+    h->size += DTREE_M_SLAB_SIZE * sizeof(char);
+  }
+
+  if (nlen > DTREE_M_SLAB_SIZE || !len) {
+    dtree_printd(DTREE_PRINT_INITDTREE, "DMALLOC: ERROR: size too large: %zu\n",
+                 len);
+    return NULL;
+  }
+
+  if (h->dc_slab_pos + nlen > DTREE_M_SLAB_SIZE) {
+    // move to next slab
+    h->dc_slab_count++;
+    h->dc_slab_pos = 0;
+    return dtree_alloc_mem_align(h, len, align);
+  }
+
+  // alloc memory
+  ret = h->dc_slabs[h->dc_slab_count] + h->dc_slab_pos + olen;
+
+  if (((size_t)ret % align)) {
+    dtree_printd(DTREE_PRINT_INITDTREE, "DMALLOC: ERROR: misalignment\n");
+    return NULL;
+  }
+
+  h->dc_count++;
+
+  dtree_printd(DTREE_PRINT_INITDTREE,
+               "DMALLOC: memory: %zu,%zu+%zu,%zu(%p) align: %zu\n",
+               h->dc_slab_count, h->dc_slab_pos, olen, len, ret, align);
+
+  h->dc_slab_pos = (ret - h->dc_slabs[h->dc_slab_count]) + len;
+
+  return (void *)ret;
 }
 
-//allocates a string, reuses if in cache
-char *dtree_alloc_string(dtree_dt_index *h,const char *s,int len)
-{
-    char *ret;
-    int i;
-    
-    if(!s)
-        return NULL;
-    
-    for(i=0;h->dc_cache[i] && i<DTREE_M_LOOKUP_CACHE;i++)
-    {
-        if(!strncmp(s,h->dc_cache[i],len) && !h->dc_cache[i][len])
-        {
-            dtree_printd(DTREE_PRINT_INITDTREE,"SALLOC: cache hit %d: '%s'\n",i,h->dc_cache[i]);
-            return h->dc_cache[i];
-        }
+// allocates a string, reuses if in cache
+char *dtree_alloc_string(dtree_dt_index *h, const char *s, int len) {
+  char *ret;
+  int i;
+
+  if (!s)
+    return NULL;
+
+  for (i = 0; h->dc_cache[i] && i < DTREE_M_LOOKUP_CACHE; i++) {
+    if (!strncmp(s, h->dc_cache[i], len) && !h->dc_cache[i][len]) {
+      dtree_printd(DTREE_PRINT_INITDTREE, "SALLOC: cache hit %d: '%s'\n", i,
+                   h->dc_cache[i]);
+      return h->dc_cache[i];
     }
-    
-    ret=dtree_alloc_mem_align(h,(len+1)*sizeof(char),sizeof(char));
-    
-    //legacy
-    if(!ret)
-        return NULL;
-    
-    strncpy(ret,s,len);
-    
-    if(!h->dc_cache[DTREE_M_LOOKUP_CACHE-1])
-    {
-        for(i=0;i<DTREE_M_LOOKUP_CACHE;i++)
-        {
-            if(!h->dc_cache[i])
-            {
-                dtree_printd(DTREE_PRINT_INITDTREE,"SALLOC: cache store %d: '%s'\n",i,ret);
-                h->dc_cache[i]=ret;
-                break;
-            }
-        }
+  }
+
+  ret = dtree_alloc_mem_align(h, (len + 1) * sizeof(char), sizeof(char));
+
+  // legacy
+  if (!ret)
+    return NULL;
+
+  strncpy(ret, s, len);
+
+  if (!h->dc_cache[DTREE_M_LOOKUP_CACHE - 1]) {
+    for (i = 0; i < DTREE_M_LOOKUP_CACHE; i++) {
+      if (!h->dc_cache[i]) {
+        dtree_printd(DTREE_PRINT_INITDTREE, "SALLOC: cache store %d: '%s'\n", i,
+                     ret);
+        h->dc_cache[i] = ret;
+        break;
+      }
     }
-    
-    dtree_printd(DTREE_PRINT_INITDTREE,"SALLOC: str allocated: '%s'(%p)\n",ret,ret);
-    
-    return ret;
+  }
+
+  dtree_printd(DTREE_PRINT_INITDTREE, "SALLOC: str allocated: '%s'(%p)\n", ret,
+               ret);
+
+  return ret;
 }
 
-//inits the head
-void dtree_init_index(dtree_dt_index *h)
-{
-    memset(h,0,sizeof(dtree_dt_index));
+// inits the head
+void dtree_init_index(dtree_dt_index *h) {
+  memset(h, 0, sizeof(dtree_dt_index));
 }
 
-//frees memory
-void dtree_free(dtree_dt_index *h)
-{
-    size_t i;
-    
-    for(i=0;i<h->slab_count;i++)
-        free(h->slabs[i]);
-    
-    for(i=0;i<DTREE_M_MAX_SLABS;i++)
-    {
-        if(h->dc_slabs[i])
-            free(h->dc_slabs[i]);
-    }
-    
-    dtree_init_index(h);
+// frees memory
+void dtree_free(dtree_dt_index *h) {
+  size_t i;
+
+  for (i = 0; i < h->slab_count; i++)
+    free(h->slabs[i]);
+
+  for (i = 0; i < DTREE_M_MAX_SLABS; i++) {
+    if (h->dc_slabs[i])
+      free(h->dc_slabs[i]);
+  }
+
+  dtree_init_index(h);
 }

--- a/src/dtree_util.c
+++ b/src/dtree_util.c
@@ -13,220 +13,210 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
-
 
 #include "dtree_client.h"
 
+static long dtree_print_node(const dtree_dt_index *, const char *(*f)(void *),
+                             const dtree_dt_node *, char *, int);
+extern int dtree_node_depth(const dtree_dt_index *, const dtree_dt_node *);
+char *dtree_node_path(const dtree_dt_index *, const dtree_dt_node *, char *);
+void dtree_timersubn(struct timespec *, struct timespec *, struct timespec *);
+int dtree_gettime(struct timespec *);
 
-static long dtree_print_node(const dtree_dt_index*,const char*(*f)(void*),const dtree_dt_node*,char*,int);
-extern int dtree_node_depth(const dtree_dt_index*,const dtree_dt_node*);
-char *dtree_node_path(const dtree_dt_index*,const dtree_dt_node*,char*);
-void dtree_timersubn(struct timespec*,struct timespec*,struct timespec*);
-int dtree_gettime(struct timespec*);
+// finds a certain flag among dup nodes
+const dtree_dt_node *dtree_get_flag(const dtree_dt_index *h,
+                                    const dtree_dt_node *n, dtree_flag_f flag,
+                                    dtree_pos_f pos) {
+  packed_ptr pp = n->curr;
 
+  while (pp) {
+    if (n->flags & flag && (!n->pos || !pos || n->pos == pos))
+      return n;
 
-//finds a certain flag among dup nodes
-const dtree_dt_node *dtree_get_flag(const dtree_dt_index *h,const dtree_dt_node *n,dtree_flag_f flag,dtree_pos_f pos)
-{
-    packed_ptr pp=n->curr;
-    
-    while(pp)
-    {
-        if(n->flags & flag && (!n->pos || !pos || n->pos==pos))
-            return n;
-        
-        pp=n->dup;
-        n=DTREE_DT_GETPP(h,pp);
-    }
-    
-    return NULL;
+    pp = n->dup;
+    n = DTREE_DT_GETPP(h, pp);
+  }
+
+  return NULL;
 }
 
-//finds a certain flag among dup nodes
-dtree_flag_f dtree_get_flags(const dtree_dt_index *h,const dtree_dt_node *n,dtree_pos_f pos)
-{
-    dtree_flag_f f;
-    packed_ptr pp;
-    
-    if(n)
-    {
-        f=0;
-        pp=n->dup;
+// finds a certain flag among dup nodes
+dtree_flag_f dtree_get_flags(const dtree_dt_index *h, const dtree_dt_node *n,
+                             dtree_pos_f pos) {
+  dtree_flag_f f;
+  packed_ptr pp;
 
-        if(!n->pos || !pos || n->pos==pos)
-            f=n->flags;
-        
-        if(pp)
-            return f | dtree_get_flags(h,DTREE_DT_GETPP(h,pp),pos);
-        else
-            return f;
-    }
+  if (n) {
+    f = 0;
+    pp = n->dup;
+
+    if (!n->pos || !pos || n->pos == pos)
+      f = n->flags;
+
+    if (pp)
+      return f | dtree_get_flags(h, DTREE_DT_GETPP(h, pp), pos);
     else
-        return 0;
-}
-
-//gets the depth of the current node
-int dtree_node_depth(const dtree_dt_index *h,const dtree_dt_node *n)
-{
-    int d=0;
-    packed_ptr pp;
-    
-    pp=n->curr;
-    
-    while(pp && n)
-    {
-        d++;
-        pp=n->prev;
-        n=DTREE_DT_GETPP(h,pp);
-    }
-    
-    return d-1;
-}
-
-//gets the pattern path of a node
-char *dtree_node_path(const dtree_dt_index *h,const dtree_dt_node *n,char *buf)
-{
-    int d;
-    packed_ptr pp;
-    
-    d=dtree_node_depth(h,n);
-    
-    buf[d]='\0';
-    pp=n->curr;
-    
-    while(pp && n && d>0)
-    {
-        d--;
-        buf[d]=n->data;
-        pp=n->prev;
-        n=DTREE_DT_GETPP(h,pp);
-    }
-    
-    return buf;
-}
-
-//walks the dtree
-long dtree_print(const dtree_dt_index *h,const char* (*f)(void*))
-{
-    unsigned int i;
-    char buf[DTREE_DATA_BUFLEN];
-    long tot=0;
-    
-    memset(buf,0,sizeof(buf));
-    
-    for(i=0;h->head && i<DTREE_HASH_NCOUNT;i++)
-        tot+=dtree_print_node(h,f,DTREE_DT_GETPP(h,h->head->nodes[i]),buf,0);
-    
-    dtree_printd(DTREE_PRINT_INITDTREE,"WALK: Walked %ld tokens\n",tot);
-    
-    return tot;
-}
-
-//walks the dtree_node
-static long dtree_print_node(const dtree_dt_index *h,const char* (*f)(void*),const dtree_dt_node *n,char *path,int depth)
-{
-    unsigned int i;
-    char buf[DTREE_DATA_BUFLEN];
-    const char *s;
-    long tot=0;
-    packed_ptr pp;
-    const dtree_dt_node *dupn;
-    
-    if(!n || !n->curr || depth>(DTREE_DATA_BUFLEN-1))
-        return 0;
-    
-    path[depth]=n->data;
-    path[depth+1]='\0';
-    
-    if(n->flags & DTREE_DT_FLAG_TOKEN)
-    {
-        s="";
-        
-        if(f)
-            s=f(n->payload);
-        
-        dtree_printd(DTREE_PRINT_INITDTREE,"PRINT: found token: '%s' flags: %d pdata: '%s' p(%p) cparam(%p)\n",
-                 path,n->flags,s,n->payload,n->cparam);
-        
-        tot++;
-        
-        dtree_node_path(h,n,buf);
-        
-        if(strcmp(path,buf))
-            dtree_printd(DTREE_PRINT_INITDTREE,"PRINT: ERROR path mismatch: '%s' != '%s'\n",path,buf);
-    }
-    
-    pp=n->dup;
-    dupn=DTREE_DT_GETPP(h,pp);
-    
-    while(pp)
-    {
-        s="";
-        
-        if(f)
-            s=f(dupn->payload);
-        
-        dtree_printd(DTREE_PRINT_INITDTREE,"PRINT: found token: '%s' flags: %d pdata: '%s' p(%p) cparam(%p)\n",
-                 path,dupn->flags,s,dupn->payload,dupn->cparam);
-
-        tot++;
-        
-        pp=dupn->dup;
-        dupn=DTREE_DT_GETPP(h,pp);
-    }
-    
-    for(i=0;i<DTREE_HASH_NCOUNT;i++)
-    {
-        if(n->nodes[i])
-            tot+=dtree_print_node(h,f,DTREE_DT_GETPP(h,n->nodes[i]),path,depth+1);
-    }
-    
-    path[depth]='\0';
-    
-    return tot;
-}
-
-//debug printf
-void dtree_printd(int level,const char* fmt,...)
-{
-#if DTREE_DEBUG_LOGGING
-    va_list ap;
-    
-    if(level & DTREE_PRINT_ENABLED)
-    {
-        va_start(ap,fmt);
-    
-        vprintf(fmt,ap);
-    
-        va_end(ap);
-    }
-#endif
-}
-
-//subtracts timers
-void dtree_timersubn(struct timespec *end,struct timespec *start,struct timespec *r)
-{
-    r->tv_sec=end->tv_sec-start->tv_sec;
-    r->tv_nsec=end->tv_nsec-start->tv_nsec;
-    
-    if(r->tv_nsec<0)
-    {
-      r->tv_sec--;
-      r->tv_nsec+=(1000*1000*1000);
-    }
-}
-
-//get timestamp
-int dtree_gettime(struct timespec *ts)
-{
-#if defined(_DTREE_NO_TIMESPEC) || defined(__MACH__)
-    ts->tv_sec=0;
-    ts->tv_nsec=0;
+      return f;
+  } else
     return 0;
-#else
-    return clock_gettime(CLOCK_REALTIME,ts);
+}
+
+// gets the depth of the current node
+int dtree_node_depth(const dtree_dt_index *h, const dtree_dt_node *n) {
+  int d = 0;
+  packed_ptr pp;
+
+  pp = n->curr;
+
+  while (pp && n) {
+    d++;
+    pp = n->prev;
+    n = DTREE_DT_GETPP(h, pp);
+  }
+
+  return d - 1;
+}
+
+// gets the pattern path of a node
+char *dtree_node_path(const dtree_dt_index *h, const dtree_dt_node *n,
+                      char *buf) {
+  int d;
+  packed_ptr pp;
+
+  d = dtree_node_depth(h, n);
+
+  buf[d] = '\0';
+  pp = n->curr;
+
+  while (pp && n && d > 0) {
+    d--;
+    buf[d] = n->data;
+    pp = n->prev;
+    n = DTREE_DT_GETPP(h, pp);
+  }
+
+  return buf;
+}
+
+// walks the dtree
+long dtree_print(const dtree_dt_index *h, const char *(*f)(void *)) {
+  unsigned int i;
+  char buf[DTREE_DATA_BUFLEN];
+  long tot = 0;
+
+  memset(buf, 0, sizeof(buf));
+
+  for (i = 0; h->head && i < DTREE_HASH_NCOUNT; i++)
+    tot += dtree_print_node(h, f, DTREE_DT_GETPP(h, h->head->nodes[i]), buf, 0);
+
+  dtree_printd(DTREE_PRINT_INITDTREE, "WALK: Walked %ld tokens\n", tot);
+
+  return tot;
+}
+
+// walks the dtree_node
+static long dtree_print_node(const dtree_dt_index *h, const char *(*f)(void *),
+                             const dtree_dt_node *n, char *path, int depth) {
+  unsigned int i;
+  char buf[DTREE_DATA_BUFLEN];
+  const char *s;
+  long tot = 0;
+  packed_ptr pp;
+  const dtree_dt_node *dupn;
+
+  if (!n || !n->curr || depth > (DTREE_DATA_BUFLEN - 1))
+    return 0;
+
+  path[depth] = n->data;
+  path[depth + 1] = '\0';
+
+  if (n->flags & DTREE_DT_FLAG_TOKEN) {
+    s = "";
+
+    if (f)
+      s = f(n->payload);
+
+    dtree_printd(
+        DTREE_PRINT_INITDTREE,
+        "PRINT: found token: '%s' flags: %d pdata: '%s' p(%p) cparam(%p)\n",
+        path, n->flags, s, n->payload, n->cparam);
+
+    tot++;
+
+    dtree_node_path(h, n, buf);
+
+    if (strcmp(path, buf))
+      dtree_printd(DTREE_PRINT_INITDTREE,
+                   "PRINT: ERROR path mismatch: '%s' != '%s'\n", path, buf);
+  }
+
+  pp = n->dup;
+  dupn = DTREE_DT_GETPP(h, pp);
+
+  while (pp) {
+    s = "";
+
+    if (f)
+      s = f(dupn->payload);
+
+    dtree_printd(
+        DTREE_PRINT_INITDTREE,
+        "PRINT: found token: '%s' flags: %d pdata: '%s' p(%p) cparam(%p)\n",
+        path, dupn->flags, s, dupn->payload, dupn->cparam);
+
+    tot++;
+
+    pp = dupn->dup;
+    dupn = DTREE_DT_GETPP(h, pp);
+  }
+
+  for (i = 0; i < DTREE_HASH_NCOUNT; i++) {
+    if (n->nodes[i])
+      tot += dtree_print_node(h, f, DTREE_DT_GETPP(h, n->nodes[i]), path,
+                              depth + 1);
+  }
+
+  path[depth] = '\0';
+
+  return tot;
+}
+
+// debug printf
+void dtree_printd(int level, const char *fmt, ...) {
+#if DTREE_DEBUG_LOGGING
+  va_list ap;
+
+  if (level & DTREE_PRINT_ENABLED) {
+    va_start(ap, fmt);
+
+    vprintf(fmt, ap);
+
+    va_end(ap);
+  }
 #endif
 }
 
+// subtracts timers
+void dtree_timersubn(struct timespec *end, struct timespec *start,
+                     struct timespec *r) {
+  r->tv_sec = end->tv_sec - start->tv_sec;
+  r->tv_nsec = end->tv_nsec - start->tv_nsec;
+
+  if (r->tv_nsec < 0) {
+    r->tv_sec--;
+    r->tv_nsec += (1000 * 1000 * 1000);
+  }
+}
+
+// get timestamp
+int dtree_gettime(struct timespec *ts) {
+#if defined(_DTREE_NO_TIMESPEC) || defined(__MACH__)
+  ts->tv_sec = 0;
+  ts->tv_nsec = 0;
+  return 0;
+#else
+  return clock_gettime(CLOCK_REALTIME, ts);
+#endif
+}

--- a/src/main.c
+++ b/src/main.c
@@ -13,192 +13,189 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
-
 
 #include "dclass_client.h"
 
+extern void dtree_timersubn(struct timespec *, struct timespec *,
+                            struct timespec *);
+extern int dtree_gettime(struct timespec *);
 
-extern void dtree_timersubn(struct timespec*,struct timespec*,struct timespec*);
-extern int dtree_gettime(struct timespec*);
+int main(int argc, char **args) {
+  int ret, i;
+  int devicemap = 0;
+  long count, ttime;
+  char buf[1024];
+  char *loadFile = "../dtrees/devicemap.dtree";
+  char *outFile = "";
+  char *parameter = NULL;
+  struct timespec startn, endn, diffn, total;
+  dclass_index di;
+  dtree_dt_index *h = &di.dti;
+  const dclass_keyvalue *kvd;
 
+  printf("dClass (version %s %s%zubit addressing %zubyte dt_node)\n",
+         dclass_get_version(), DTREE_DT_PTR_TYPE, DTREE_DT_PTR_SIZE,
+         sizeof(dtree_dt_node));
 
-int main(int argc,char **args)
-{
-    int ret,i;
-    int devicemap=0;
-    long count,ttime;
-    char buf[1024];
-    char *loadFile="../dtrees/devicemap.dtree";
-    char *outFile="";
-    char *parameter=NULL;
-    struct timespec startn,endn,diffn,total;
-    dclass_index di;
-    dtree_dt_index *h=&di.dti;
-    const dclass_keyvalue *kvd;
-    
-    printf("dClass (version %s %s%zubit addressing %zubyte dt_node)\n",dclass_get_version(),
-        DTREE_DT_PTR_TYPE,DTREE_DT_PTR_SIZE,sizeof(dtree_dt_node));
-    
-    for(i=1;i<argc;i++)
-    {
-        //-l [dtree file]
-        if(!strcmp(args[i],"-l") && argc>(i+1))
-            loadFile=args[++i];
-        //-o [output dtree file]
-        else if(!strcmp(args[i],"-o") && argc>(i+1))
-            outFile=args[++i];
-        //-m [open ddr resource dir]
-        else if(!strcmp(args[i],"-d") && argc>(i+1))
-        {
-            devicemap=1;
-            loadFile=args[++i];
-        }
-        else if(!strncmp(args[i],"-h",2) || !strncmp(args[i],"--h",3))
-        {
-            printf("Usage: dclass_client [OPTIONS] [FILE|STRING]\n\n");
-            printf("  -l <path>            load dtree from file\n");
-            printf("  -o <path>            store dtree to file\n");
-            printf("  -d <folder path>     load DeviceMap resources xmls\n");
-            printf("  FILE                 STRING text file\n");
-            printf("  STRING               test string\n");
-            
-            return 0;
-        }
-        //[test string] | [test file]
-        else
-            parameter=args[i];
+  for (i = 1; i < argc; i++) {
+    //-l [dtree file]
+    if (!strcmp(args[i], "-l") && argc > (i + 1))
+      loadFile = args[++i];
+    //-o [output dtree file]
+    else if (!strcmp(args[i], "-o") && argc > (i + 1))
+      outFile = args[++i];
+    //-m [open ddr resource dir]
+    else if (!strcmp(args[i], "-d") && argc > (i + 1)) {
+      devicemap = 1;
+      loadFile = args[++i];
+    } else if (!strncmp(args[i], "-h", 2) || !strncmp(args[i], "--h", 3)) {
+      printf("Usage: dclass_client [OPTIONS] [FILE|STRING]\n\n");
+      printf("  -l <path>            load dtree from file\n");
+      printf("  -o <path>            store dtree to file\n");
+      printf("  -d <folder path>     load DeviceMap resources xmls\n");
+      printf("  FILE                 STRING text file\n");
+      printf("  STRING               test string\n");
+
+      return 0;
     }
-
-    printf("Loading %s: '%s'\n",devicemap?"devicemap":"dtree",loadFile);
-    
-    dtree_gettime(&startn);
-    
-    if(devicemap)
-        ret=devicemap_load_resources(&di,loadFile);
+    //[test string] | [test file]
     else
-        ret=dclass_load_file(&di,loadFile);
-    
-    dtree_gettime(&endn);
-    dtree_timersubn(&endn,&startn,&diffn);
-    
-    printf("load dtree tokens: %d time: %lds %ldms %ldus %ldns\n",
-           ret,diffn.tv_sec,diffn.tv_nsec/1000000,diffn.tv_nsec/1000%1000,diffn.tv_nsec%1000);
-    
-    printf("dtree stats: nodes: %zu slabs: %zu mem: %zu bytes strings: %zu(%zu,%zu)\n",
-           h->node_count,h->slab_count,h->size,h->dc_count,h->dc_slab_count,h->dc_slab_pos);
-    
-    printf("dtree comment: '%s'\n",(h->comment?h->comment:""));
+      parameter = args[i];
+  }
 
-    dtree_gettime(&startn);
-    
-    count=dtree_print(h,&dclass_get_id);
-    
-    dtree_gettime(&endn);
-    dtree_timersubn(&endn,&startn,&diffn);
-    
-    printf("walk tree: %ld tokens %zu nodes time: %lds %ldms %ldus %ldns\n",
-           count,h->node_count,diffn.tv_sec,diffn.tv_nsec/1000000,diffn.tv_nsec/1000%1000,diffn.tv_nsec%1000);
-    
-    if(*outFile)
-    {
-        printf("Dumping dtree: '%s'\n",outFile);
-        
-        ret=dclass_write_file(&di,outFile);
-        
-        printf("Wrote %d entries\n",ret);
-    }
-    
-    dtree_gettime(&startn);
-    
-    kvd=dclass_classify(&di,"Mozilla/5.0 (Linux; U; Android 2.2; en; HTC Aria A6380 Build/ERE27) AppleWebKit/540.13+ (KHTML, like Gecko) Version/3.1 Mobile Safari/524.15.0");
-    
-    dtree_gettime(&endn);
-    dtree_timersubn(&endn,&startn,&diffn);
-    
-    printf("HTC Aria UA lookup: '%s' time: %lds %ldms %ldus %ldns\n",
-           kvd->id,diffn.tv_sec,diffn.tv_nsec/1000000,diffn.tv_nsec/1000%1000,diffn.tv_nsec%1000);
-    
-    if(parameter)
-    {
-        FILE *f;
-        
-        if((f=fopen(parameter,"r")))
-        {
-            printf("UA file: '%s'\n",parameter);
-            
-            count=0;
-            
-            memset(&total,0,sizeof(total));
-            
-            while(fgets(buf,sizeof(buf),f))
-            {
+  printf("Loading %s: '%s'\n", devicemap ? "devicemap" : "dtree", loadFile);
+
+  dtree_gettime(&startn);
+
+  if (devicemap)
+    ret = devicemap_load_resources(&di, loadFile);
+  else
+    ret = dclass_load_file(&di, loadFile);
+
+  dtree_gettime(&endn);
+  dtree_timersubn(&endn, &startn, &diffn);
+
+  printf("load dtree tokens: %d time: %lds %ldms %ldus %ldns\n", ret,
+         diffn.tv_sec, diffn.tv_nsec / 1000000, diffn.tv_nsec / 1000 % 1000,
+         diffn.tv_nsec % 1000);
+
+  printf("dtree stats: nodes: %zu slabs: %zu mem: %zu bytes strings: "
+         "%zu(%zu,%zu)\n",
+         h->node_count, h->slab_count, h->size, h->dc_count, h->dc_slab_count,
+         h->dc_slab_pos);
+
+  printf("dtree comment: '%s'\n", (h->comment ? h->comment : ""));
+
+  dtree_gettime(&startn);
+
+  count = dtree_print(h, &dclass_get_id);
+
+  dtree_gettime(&endn);
+  dtree_timersubn(&endn, &startn, &diffn);
+
+  printf("walk tree: %ld tokens %zu nodes time: %lds %ldms %ldus %ldns\n",
+         count, h->node_count, diffn.tv_sec, diffn.tv_nsec / 1000000,
+         diffn.tv_nsec / 1000 % 1000, diffn.tv_nsec % 1000);
+
+  if (*outFile) {
+    printf("Dumping dtree: '%s'\n", outFile);
+
+    ret = dclass_write_file(&di, outFile);
+
+    printf("Wrote %d entries\n", ret);
+  }
+
+  dtree_gettime(&startn);
+
+  kvd = dclass_classify(&di, "Mozilla/5.0 (Linux; U; Android 2.2; en; HTC Aria "
+                             "A6380 Build/ERE27) AppleWebKit/540.13+ (KHTML, "
+                             "like Gecko) Version/3.1 Mobile Safari/524.15.0");
+
+  dtree_gettime(&endn);
+  dtree_timersubn(&endn, &startn, &diffn);
+
+  printf("HTC Aria UA lookup: '%s' time: %lds %ldms %ldus %ldns\n", kvd->id,
+         diffn.tv_sec, diffn.tv_nsec / 1000000, diffn.tv_nsec / 1000 % 1000,
+         diffn.tv_nsec % 1000);
+
+  if (parameter) {
+    FILE *f;
+
+    if ((f = fopen(parameter, "r"))) {
+      printf("UA file: '%s'\n", parameter);
+
+      count = 0;
+
+      memset(&total, 0, sizeof(total));
+
+      while (fgets(buf, sizeof(buf), f)) {
 #if DTREE_TEST_UALOOKUP
-                int slen=strlen(buf)-1;
-                
-                if(buf[slen]=='\n')
-                    buf[slen]='\0';
-                
-                printf("UA: '%s'\n",buf);
-                
-                fflush(stdout);
+        int slen = strlen(buf) - 1;
+
+        if (buf[slen] == '\n')
+          buf[slen] = '\0';
+
+        printf("UA: '%s'\n", buf);
+
+        fflush(stdout);
 #endif
 
-                dtree_gettime(&startn);
-                
-                kvd=dclass_classify(&di,buf);
-                
-                dtree_gettime(&endn);
-                dtree_timersubn(&endn,&startn,&diffn);
-                
-                total.tv_sec+=diffn.tv_sec;
-                total.tv_nsec+=diffn.tv_nsec;
-                
-                count++;
-                
-#if DTREE_TEST_UALOOKUP
-                printf("UA lookup %ld: '%s' time: %lds %ldms %ldus %ldns\n",
-                       count,kvd->id,diffn.tv_sec,diffn.tv_nsec/1000000,diffn.tv_nsec/1000%1000,diffn.tv_nsec%1000);
-#endif
-            }
-            
-            fclose(f);
-            
-            if(!count)
-                count=1;
-            
-            ttime=(total.tv_sec*1000*1000*1000)+total.tv_nsec;
-            ttime/=count;
-            
-            printf("TOTAL average time: %ld lookups, %lds %ldms %ldus %ldns\n",
-                   count,ttime/1000000000,ttime/1000000%1000000,ttime/1000%1000,ttime%1000);
-        }
-        else
-        {
-            printf("UA: '%s'\n",parameter);
-            
-            dtree_gettime(&startn);
-            
-            kvd=dclass_classify(&di,parameter);
-            
-            dtree_gettime(&endn);
-            dtree_timersubn(&endn,&startn,&diffn);
-            
-            printf("Param UA lookup: '%s' time: %lds %ldms %ldus %ldns\n",
-                   kvd->id,diffn.tv_sec,diffn.tv_nsec/1000000,diffn.tv_nsec/1000%1000,diffn.tv_nsec%1000);
-            
-            if(kvd && kvd->size)
-            {
-                printf("DeviceMap attributes => ");
-                for(i=0;i<kvd->size;i++)
-                        printf("%s: '%s' ",kvd->keys[i],kvd->values[i]);
-                printf("\n");
-            }
-        }
-    }
+        dtree_gettime(&startn);
 
-    dclass_free(&di);
-    
-    return 0;
+        kvd = dclass_classify(&di, buf);
+
+        dtree_gettime(&endn);
+        dtree_timersubn(&endn, &startn, &diffn);
+
+        total.tv_sec += diffn.tv_sec;
+        total.tv_nsec += diffn.tv_nsec;
+
+        count++;
+
+#if DTREE_TEST_UALOOKUP
+        printf("UA lookup %ld: '%s' time: %lds %ldms %ldus %ldns\n", count,
+               kvd->id, diffn.tv_sec, diffn.tv_nsec / 1000000,
+               diffn.tv_nsec / 1000 % 1000, diffn.tv_nsec % 1000);
+#endif
+      }
+
+      fclose(f);
+
+      if (!count)
+        count = 1;
+
+      ttime = (total.tv_sec * 1000 * 1000 * 1000) + total.tv_nsec;
+      ttime /= count;
+
+      printf("TOTAL average time: %ld lookups, %lds %ldms %ldus %ldns\n", count,
+             ttime / 1000000000, ttime / 1000000 % 1000000, ttime / 1000 % 1000,
+             ttime % 1000);
+    } else {
+      printf("UA: '%s'\n", parameter);
+
+      dtree_gettime(&startn);
+
+      kvd = dclass_classify(&di, parameter);
+
+      dtree_gettime(&endn);
+      dtree_timersubn(&endn, &startn, &diffn);
+
+      printf("Param UA lookup: '%s' time: %lds %ldms %ldus %ldns\n", kvd->id,
+             diffn.tv_sec, diffn.tv_nsec / 1000000, diffn.tv_nsec / 1000 % 1000,
+             diffn.tv_nsec % 1000);
+
+      if (kvd && kvd->size) {
+        printf("DeviceMap attributes => ");
+        for (i = 0; i < kvd->size; i++)
+          printf("%s: '%s' ", kvd->keys[i], kvd->values[i]);
+        printf("\n");
+      }
+    }
+  }
+
+  dclass_free(&di);
+
+  return 0;
 }


### PR DESCRIPTION
This was done using `clang-format -i`. Somehow this broke a few of the
statements, by reflowing the end of comments into code, requiring
manual fixes.